### PR TITLE
CIVIL-1072 - Claims API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,13 @@ require (
 	github.com/iden3/go-iden3-core v0.0.7-0.20190910103140-0195e977d998
 	github.com/iden3/go-iden3-crypto v0.0.3-0.20190831180703-c95c95b7b161
 	github.com/jinzhu/gorm v1.9.10
-	github.com/joincivil/go-common v0.0.0-20190925152827-26fccd64f4e8
+	github.com/joincivil/go-common v0.0.0-20191010200949-5c3ab2eca14a
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/lib/pq v1.2.0 // indirect
+	github.com/machinebox/graphql v0.2.2
+	github.com/matryer/is v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
@@ -30,8 +32,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.21.0
 	github.com/vektah/gqlparser v1.1.2
-	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect
 	google.golang.org/appengine v1.6.3 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,7 @@ github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+s
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/allegro/bigcache v1.1.0/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/allegro/bigcache v1.2.0/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
 github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -28,7 +28,7 @@ github.com/apilayer/freegeoip v3.5.0+incompatible h1:z1u2gv0/rsSi/HqMDB436AiUROX
 github.com/apilayer/freegeoip v3.5.0+incompatible/go.mod h1:CUfFqErhFhXneJendyQ/rRcuA8kH8JxHvYnbOozmlCU=
 github.com/aristanetworks/fsnotify v1.4.2/go.mod h1:D/rtu7LpjYM8tRJphJ0hUBYpjai8SfX+aSNsWDTq/Ks=
 github.com/aristanetworks/glog v0.0.0-20180419172825-c15b03b3054f/go.mod h1:KASm+qXFKs/xjSoWn30NrWBBvdTTQq+UjkhjEJHfSFA=
-github.com/aristanetworks/goarista v0.0.0-20181210134948-aa2a42e13be6/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
+github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/aristanetworks/goarista v0.0.0-20190712234253-ed1100a1c015 h1:7ABPr1+uJdqESAdlVevnc/2FJGiC/K3uMg1JiELeF+0=
 github.com/aristanetworks/goarista v0.0.0-20190712234253-ed1100a1c015/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/aristanetworks/goarista v0.0.0-20190924011532-60b7b74727fd h1:2gXWYquahfk3RfmyLuMk47NCaf+1FFQ95FNM+HZN3Oo=
@@ -158,7 +158,6 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -219,8 +218,8 @@ github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/joincivil/go-common v0.0.0-20190925152827-26fccd64f4e8 h1:tE8a/Ga8rvpQldjWFCPT2s67764FpMPOC1ad9YD0lwc=
-github.com/joincivil/go-common v0.0.0-20190925152827-26fccd64f4e8/go.mod h1:dvrXugRcyihRjoe2skNN/OgvvgTIrSxrGMc6kiCn7+Q=
+github.com/joincivil/go-common v0.0.0-20191010200949-5c3ab2eca14a h1:678l31feUN6f/nR6Hpk3jrZtTlJQQa9el/PcDw3mW1w=
+github.com/joincivil/go-common v0.0.0-20191010200949-5c3ab2eca14a/go.mod h1:rsFDwXyDKsUrm4pgE10z7AAaAuvFZ4NtN0ghSF3OwL8=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -269,6 +268,10 @@ github.com/libp2p/go-libp2p-metrics v0.1.0/go.mod h1:rpoJmXWFxnj7qs5sJ02sxSzrhaZ
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
 github.com/libp2p/go-libp2p-peer v0.2.0/go.mod h1:RCffaCvUyW2CJmG2gAWVqwePwW7JMgxjsHm7+J5kjWY=
 github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1VZNHYcK8cLgFJLZ4s=
+github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkBZfo=
+github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
+github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -413,7 +416,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/syndtr/goleveldb v0.0.0-20181128100959-b001fa50d6b2/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161/go.mod h1:wM7WEvslTq+iOEAMDLSzhVuOt5BRZ05WirO+b09GHQU=
@@ -453,7 +455,6 @@ golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443 h1:IcSOAf4PyMp3U3XbIEj1/x
 golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4 h1:ydJNl0ENAG67pFbB+9tfhiL2pYqLhfoaZFw/cjLhY4A=
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -484,7 +485,6 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190918130420-a8b05e9114ab/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -497,6 +497,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -522,7 +523,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190912141932-bc967efca4b8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -60,25 +60,34 @@ func Middleware() func(http.Handler) http.Handler {
 	}
 }
 
-// ForContext checks signature based on the header data.
+// ForContextData is returned by ForContext and contains data pulled from the
+// context
+type ForContextData struct {
+	Did string
+}
+
+// ForContext checks signature based on the header data. If error returned,
+// indicates an invalid signature or no auth passed. Returns auth context data
+// for convenience.
 // REQUIRES Middleware to have run.
-func ForContext(ctx context.Context, ds *did.Service, pks []did.DocPublicKey) error {
+func ForContext(ctx context.Context, ds *did.Service, pks []did.DocPublicKey) (
+	*ForContextData, error) {
 	// NOTE(PN): Supporting only Secp251k1 keys for authentication for now
 	keyType := linkeddata.SuiteTypeSecp256k1Verification
 
 	reqTs, _ := ctx.Value(reqTsCtxKey).(string)
 	if reqTs == "" {
-		return errors.New("no request ts passed in context")
+		return nil, errors.New("no request ts passed in context")
 	}
 	signature, _ := ctx.Value(signatureCtxKey).(string)
 	if signature == "" {
-		return errors.New("no signature passed in context")
+		return nil, errors.New("no signature passed in context")
 	}
 	didStr, _ := ctx.Value(didCtxKey).(string)
 
 	ts, err := strconv.Atoi(reqTs)
 	if err != nil {
-		return errors.Wrap(err, "could not convert ts to int")
+		return nil, errors.Wrap(err, "could not convert ts to int")
 	}
 
 	// altered grace period value can be passed in the context
@@ -93,18 +102,18 @@ func ForContext(ctx context.Context, ds *did.Service, pks []did.DocPublicKey) er
 	if didStr != "" {
 		err = VerifyEcdsaRequestSignatureWithDid(ds, keyType, signature, ts, didStr, gracePeriod)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 	} else if pks != nil {
 		err = VerifyEcdsaRequestSignatureWithPks(pks, keyType, signature, ts, "", gracePeriod)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 	} else {
-		return errors.New("could not verify signature, no did or public keys")
+		return nil, errors.New("could not verify signature, no did or public keys")
 	}
 
-	return nil
+	return &ForContextData{Did: didStr}, nil
 }

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -65,9 +65,18 @@ func ForContext(ctx context.Context, ds *did.Service, pks []did.DocPublicKey) er
 	// NOTE(PN): Supporting only Secp251k1 keys for authentication for now
 	keyType := linkeddata.SuiteTypeSecp256k1Verification
 
-	reqTs, _ := ctx.Value(reqTsCtxKey).(string)
-	signature, _ := ctx.Value(signatureCtxKey).(string)
-	didStr, _ := ctx.Value(didCtxKey).(string)
+	reqTs, ok := ctx.Value(reqTsCtxKey).(string)
+	if !ok {
+		return errors.New("no request ts passed in context")
+	}
+	signature, ok := ctx.Value(signatureCtxKey).(string)
+	if !ok {
+		return errors.New("no signature passed in context")
+	}
+	didStr, ok := ctx.Value(didCtxKey).(string)
+	if !ok {
+		return errors.New("no did passed in context")
+	}
 
 	ts, err := strconv.Atoi(reqTs)
 	if err != nil {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -116,7 +116,7 @@ type testHandlerForContext struct {
 
 func (h *testHandlerForContext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	err := ForContext(ctx, h.ds, nil)
+	_, err := ForContext(ctx, h.ds, nil)
 	if err != nil {
 		h.t.Errorf("Should not have returned a bad verification: err: %v", err)
 	}
@@ -163,7 +163,7 @@ type testHandlerForContextNewDid struct {
 
 func (h *testHandlerForContextNewDid) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	err := ForContext(ctx, h.ds, h.pks)
+	_, err := ForContext(ctx, h.ds, h.pks)
 	if err != nil {
 		h.t.Errorf("Should have returned verified: err: %v", err)
 	}
@@ -215,7 +215,7 @@ type testHandlerForContextNewDidNoPk struct {
 
 func (h *testHandlerForContextNewDidNoPk) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	err := ForContext(ctx, h.ds, h.pks)
+	_, err := ForContext(ctx, h.ds, h.pks)
 	if err == nil {
 		h.t.Errorf("Should have not been verified")
 	}
@@ -258,7 +258,7 @@ type testHandlerForContextBad struct {
 
 func (h *testHandlerForContextBad) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	err := ForContext(ctx, h.ds, nil)
+	_, err := ForContext(ctx, h.ds, nil)
 	if err == nil {
 		h.t.Errorf("Should have returned a bad verification")
 	}

--- a/pkg/auth/signature_test.go
+++ b/pkg/auth/signature_test.go
@@ -28,7 +28,8 @@ func TestSignVerifyEcdsaRequestSignature(t *testing.T) {
 	// Verify this signature is valid
 	pubKeyBys := crypto.FromECDSAPub(&pk.PublicKey)
 	pubKeyHex := hex.EncodeToString(pubKeyBys)
-	verified, err := auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did, reqTs)
+	verified, err := auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did,
+		reqTs, auth.DefaultRequestGracePeriodSecs)
 	if err != nil {
 		t.Errorf("Should not have returned error when verifying: err: %v", err)
 	}
@@ -54,7 +55,8 @@ func TestSignVerifyEcdsaRequestSignatureGracePeriod(t *testing.T) {
 
 	pubKeyBys := crypto.FromECDSAPub(&pk.PublicKey)
 	pubKeyHex := hex.EncodeToString(pubKeyBys)
-	verified, err := auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did, reqTs)
+	verified, err := auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did,
+		reqTs, auth.DefaultRequestGracePeriodSecs)
 	if err != nil {
 		t.Errorf("Should not have returned error when verifying: err: %v", err)
 	}
@@ -72,7 +74,8 @@ func TestSignVerifyEcdsaRequestSignatureGracePeriod(t *testing.T) {
 		t.Fatalf("Should have returned a non-empty signature")
 	}
 
-	verified, err = auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did, reqTs)
+	verified, err = auth.VerifyEcdsaRequestSignature(pubKeyHex, signature, did, reqTs,
+		auth.DefaultRequestGracePeriodSecs)
 	if err != nil {
 		t.Errorf("Should not have returned error when verifying")
 	}
@@ -99,7 +102,8 @@ func TestSignVerifyEcdsaRequestSignatureErrs(t *testing.T) {
 	// Bad publicKey when verifying
 	did = "did:ethurl:123456"
 	badPubKey := "thisisabadkey"
-	verified, err := auth.VerifyEcdsaRequestSignature(badPubKey, signature, did, reqTs)
+	verified, err := auth.VerifyEcdsaRequestSignature(badPubKey, signature, did, reqTs,
+		auth.DefaultRequestGracePeriodSecs)
 	if err == nil {
 		t.Errorf("Should have returned error when verifying")
 	}
@@ -111,7 +115,8 @@ func TestSignVerifyEcdsaRequestSignatureErrs(t *testing.T) {
 	pubKeyBys := crypto.FromECDSAPub(&pk.PublicKey)
 	did = "did:ethurl:123456"
 	badSignature := "thisisabadsignature"
-	verified, err = auth.VerifyEcdsaRequestSignature(string(pubKeyBys), badSignature, did, reqTs)
+	verified, err = auth.VerifyEcdsaRequestSignature(string(pubKeyBys), badSignature,
+		did, reqTs, auth.DefaultRequestGracePeriodSecs)
 	if err == nil {
 		t.Errorf("Should have returned error when verifying")
 	}

--- a/pkg/claims/creds_test.go
+++ b/pkg/claims/creds_test.go
@@ -1,0 +1,69 @@
+// +build creds
+
+package claims_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
+	"github.com/joincivil/id-hub/pkg/did"
+	"github.com/joincivil/id-hub/pkg/linkeddata"
+	didlib "github.com/ockam-network/did"
+)
+
+// Used to generated some predetermined test creds
+func TestMakeTestCredentials(t *testing.T) {
+	db, err := setupConnection()
+	if err != nil {
+		t.Errorf("error setting up the db: %v", err)
+	}
+
+	didPersister := did.NewPostgresPersister(db)
+	didService := did.NewService(didPersister)
+	signedClaimStore := claimsstore.NewSignedClaimPGPersister(db)
+	claimService, err := makeService(db, didService, signedClaimStore)
+	if err != nil {
+		t.Errorf("error setting up service: %v", err)
+	}
+
+	pub := "049691d8097f07afb7068a971ba500abd30b2ef763240bc56bf021ff592ed08446b7d23df1a5a043e7472d8954764f3fd39fbf992517e9c61ba10afee1965391e6"
+	docPubKey := &did.DocPublicKey{
+		Type:         linkeddata.SuiteTypeSecp256k1Verification,
+		PublicKeyHex: &pub,
+	}
+
+	signerDid, err := didlib.Parse("did:ethuri:e7ab0c43-d9fe-4a61-87a3-3fa99ce879e1")
+	if err != nil {
+		t.Errorf("error creating did: %v", err)
+	}
+	docPubKey.ID = signerDid
+	docPubKey.Controller = did.CopyDID(signerDid)
+	didDoc, err := did.InitializeNewDocument(signerDid, docPubKey, true, true)
+	if err != nil {
+		t.Errorf("error making the did doc: %v", err)
+	}
+	if err := didService.SaveDocument(didDoc); err != nil {
+		t.Errorf("error saving the did doc: %v", err)
+	}
+
+	pubBytes, _ := hex.DecodeString(pub)
+	ecdsaPubkey, _ := crypto.UnmarshalPubkey(pubBytes)
+	err = claimService.CreateTreeForDID(&didDoc.ID, ecdsaPubkey)
+	if err != nil {
+		t.Errorf("problem creating did tree: %v", err)
+	}
+
+	bys, _ := json.MarshalIndent(didDoc, "", "    ")
+
+	t.Logf("test did:\n%v", signerDid)
+	t.Logf("test doc:\n%v", string(bys))
+
+	cred := makeContentCredential(&didDoc.ID)
+	addProof(cred, didDoc.PublicKeys[0].ID)
+
+	bys, _ = json.MarshalIndent(cred, "", "    ")
+	t.Logf("test cred:\n%v\n", string(bys))
+}

--- a/pkg/claims/creds_test.go
+++ b/pkg/claims/creds_test.go
@@ -2,68 +2,181 @@
 
 package claims_test
 
+// This are to manually test saving claims to an ID Hub with authentication.
+// NOTE: An ID Hub should be running on localhost:8080 and postgresql should be up.
+// go test -cpu 4 -v -race -timeout=180s -tags=creds -logtostderr=true -stderrthreshold=INFO -run TestCredentialsAndGqlClaimSave
+
+// Manually ensure the DB is cleaned up since the server and this test mutates data.
+
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
 	"testing"
+	"time"
+
+	gql "github.com/machinebox/graphql"
+
+	ctime "github.com/joincivil/go-common/pkg/time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/joincivil/id-hub/pkg/auth"
+	"github.com/joincivil/id-hub/pkg/claims"
 	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/did"
+	"github.com/joincivil/id-hub/pkg/graphql"
 	"github.com/joincivil/id-hub/pkg/linkeddata"
+
 	didlib "github.com/ockam-network/did"
 )
 
-// Used to generated some predetermined test creds
-func TestMakeTestCredentials(t *testing.T) {
-	db, err := setupConnection()
+const (
+	testDid = "did:ethuri:e7ab0c43-d9fe-4a61-87a3-3fa99ce879e1"
+)
+
+func testClaimSaveGQL(t *testing.T, credStr string, reqTs int, thedid string,
+	sig string) error {
+	client := gql.NewClient("http://localhost:8080/v1/query")
+	req := gql.NewRequest(`
+		mutation($in: ClaimSaveRequestInput!) {
+			claimSave(in: $in) {
+				claimRaw
+			}
+		}
+	`)
+
+	req.Header.Add("X-IDHUB-DID", testDid)
+	req.Header.Add("X-IDHUB-REQTS", strconv.Itoa(reqTs))
+	req.Header.Add("X-IDHUB-SIGNATURE", sig)
+
+	req.Var("in", graphql.ClaimSaveRequestInput{ClaimJSON: &credStr})
+
+	resp := struct {
+		ClaimRaw string `json:"claimRaw"`
+	}{}
+	err := client.Run(context.Background(), req, &resp)
 	if err != nil {
-		t.Errorf("error setting up the db: %v", err)
+		t.Logf("err running graphql")
+		return err
 	}
 
+	t.Logf("returned from gql: %+v", resp.ClaimRaw)
+	return nil
+}
+
+func testServerUp() error {
+	conn, err := net.Dial("tcp", "127.0.0.1:8080")
+	if err != nil {
+		return err
+	} else {
+		conn.Close()
+	}
+	return nil
+}
+
+// Used to generated some predetermined test creds
+func TestCredentialsAndGqlClaimSave(t *testing.T) {
+	err := testServerUp()
+	if err != nil {
+		t.Fatalf("server not up, please start up the ID Hub at 8080, err: %v", err)
+	}
+
+	// Setup DB
+	db, err := setupConnection()
+	if err != nil {
+		t.Fatalf("error setting up the db: %v", err)
+	}
+
+	// Setup services
 	didPersister := did.NewPostgresPersister(db)
 	didService := did.NewService(didPersister)
 	signedClaimStore := claimsstore.NewSignedClaimPGPersister(db)
 	claimService, err := makeService(db, didService, signedClaimStore)
 	if err != nil {
-		t.Errorf("error setting up service: %v", err)
+		t.Fatalf("error setting up service: %v", err)
 	}
 
-	pub := "049691d8097f07afb7068a971ba500abd30b2ef763240bc56bf021ff592ed08446b7d23df1a5a043e7472d8954764f3fd39fbf992517e9c61ba10afee1965391e6"
+	// New private key
+	privKey, _ := crypto.GenerateKey()
+	privBys := crypto.FromECDSA(privKey)
+	priv := hex.EncodeToString(privBys)
+
+	// New pub key
+	pubKey := privKey.PublicKey
+	pubBys := crypto.FromECDSAPub(&pubKey)
+	pub := hex.EncodeToString(pubBys)
+
+	t.Logf("priv key hex:\n%v", priv)
+	t.Logf("pub key hex:\n%v", pub)
+	t.Logf("did:\n%v", testDid)
+
 	docPubKey := &did.DocPublicKey{
 		Type:         linkeddata.SuiteTypeSecp256k1Verification,
 		PublicKeyHex: &pub,
 	}
 
-	signerDid, err := didlib.Parse("did:ethuri:e7ab0c43-d9fe-4a61-87a3-3fa99ce879e1")
+	// Create DID and DID document
+	signerDid, err := didlib.Parse(testDid)
 	if err != nil {
-		t.Errorf("error creating did: %v", err)
+		t.Fatalf("error creating did: %v", err)
 	}
-	docPubKey.ID = signerDid
+	docPubKey.ID = did.CopyDID(signerDid)
 	docPubKey.Controller = did.CopyDID(signerDid)
 	didDoc, err := did.InitializeNewDocument(signerDid, docPubKey, true, true)
 	if err != nil {
-		t.Errorf("error making the did doc: %v", err)
+		t.Fatalf("error making the did doc: %v", err)
 	}
-	if err := didService.SaveDocument(didDoc); err != nil {
-		t.Errorf("error saving the did doc: %v", err)
-	}
-
-	pubBytes, _ := hex.DecodeString(pub)
-	ecdsaPubkey, _ := crypto.UnmarshalPubkey(pubBytes)
-	err = claimService.CreateTreeForDID(&didDoc.ID, ecdsaPubkey)
+	err = didService.SaveDocument(didDoc)
 	if err != nil {
-		t.Errorf("problem creating did tree: %v", err)
+		t.Fatalf("error saving the did doc: %v", err)
+	}
+	t.Logf("saved did document")
+
+	// New claims tree for the DID
+	err = claimService.CreateTreeForDID(&didDoc.ID, &pubKey)
+	if err != nil {
+		t.Fatalf("problem creating did tree: %v", err)
 	}
 
 	bys, _ := json.MarshalIndent(didDoc, "", "    ")
-
 	t.Logf("test did:\n%v", signerDid)
-	t.Logf("test doc:\n%v", string(bys))
+	t.Logf("test did doc:\n%v", string(bys))
 
+	// Create a new content credential / claim
 	cred := makeContentCredential(&didDoc.ID)
-	addProof(cred, didDoc.PublicKeys[0].ID)
+	canoncred, _ := claims.CanonicalizeCredential(cred)
+	fmt.Printf("canoncred = %v\n", string(canoncred))
 
-	bys, _ = json.MarshalIndent(cred, "", "    ")
+	// Create proof on credential
+	proofValue, _ := auth.SignMessage(privKey, canoncred)
+	fmt.Printf("proof val = %v\n", proofValue)
+	cred.Proof = linkeddata.Proof{
+		Type:       string(linkeddata.SuiteTypeSecp256k1Signature),
+		Creator:    didDoc.PublicKeys[0].ID.String(),
+		Created:    time.Now(),
+		ProofValue: proofValue,
+	}
+
+	// Sign the request message using the private key
+	reqTs := ctime.CurrentEpochSecsInInt()
+	sig, err := auth.SignEcdsaRequestMessage(privKey, testDid, reqTs)
+	if err != nil {
+		t.Fatalf("unable to sign message: err: %v", err)
+	}
+
+	bys, _ = json.Marshal(cred)
+	t.Logf("req sig:\n%v\n", sig)
 	t.Logf("test cred:\n%v\n", string(bys))
+
+	// time.Sleep(time.Millisecond * 2000)
+
+	// Send the GQL request
+	t.Logf("calling gql")
+	err = testClaimSaveGQL(t, string(bys), reqTs, testDid, sig)
+	if err != nil {
+		t.Fatalf("error calling gql: %v", err)
+	}
 }

--- a/pkg/claims/service.go
+++ b/pkg/claims/service.go
@@ -32,7 +32,8 @@ type Service struct {
 }
 
 // NewService returns a new service
-func NewService(treeStore db.Storage, signedClaimStore *claimsstore.SignedClaimPGPersister, didService *did.Service) (*Service, error) {
+func NewService(treeStore db.Storage, signedClaimStore *claimsstore.SignedClaimPGPersister,
+	didService *did.Service) (*Service, error) {
 	rootStore := treeStore.WithPrefix(claimsstore.PrefixRootMerkleTree)
 
 	rootMt, err := merkletree.NewMerkleTree(rootStore, 150)

--- a/pkg/claims/service.go
+++ b/pkg/claims/service.go
@@ -214,7 +214,6 @@ func (s *Service) ClaimsToContentCredentials(clms []merkletree.Claim) (
 			claimHash := hex.EncodeToString(regDoc.ContentHash[:])
 			signed, err := s.signedClaimStore.GetCredentialByHash(claimHash)
 			if err != nil {
-				// log.Errorf("could not retrieve credential: hash: %v, err: %v", claimHash, err)
 				return nil, errors.Wrapf(err, "could not retrieve credential: hash: %v, err: %v", claimHash, err)
 			}
 			creds[ind] = signed

--- a/pkg/claims/service_test.go
+++ b/pkg/claims/service_test.go
@@ -218,3 +218,72 @@ func TestClaimContent(t *testing.T) {
 		}
 	}
 }
+
+func TestClaimsToContentCredentials(t *testing.T) {
+	db, err := setupConnection()
+	if err != nil {
+		t.Errorf("error setting up the db: %v", err)
+	}
+
+	cleaner := testutils.DeleteCreatedEntities(db)
+	defer cleaner()
+
+	// Setup
+	didPersister := did.NewPostgresPersister(db)
+	didService := did.NewService(didPersister)
+	signedClaimStore := claimsstore.NewSignedClaimPGPersister(db)
+	claimService, err := makeService(db, didService, signedClaimStore)
+	if err != nil {
+		t.Errorf("error setting up service: %v", err)
+	}
+
+	// Create a DID identity
+	pub := "049691d8097f07afb7068a971ba500abd30b2ef763240bc56bf021ff592ed08446b7d23df1a5a043e7472d8954764f3fd39fbf992517e9c61ba10afee1965391e6"
+	docPubKey := &did.DocPublicKey{
+		Type:         linkeddata.SuiteTypeSecp256k1Verification,
+		PublicKeyHex: &pub,
+	}
+	signerDid, err := didlib.Parse("did:ethuri:e7ab0c43-d9fe-4a61-87a3-3fa99ce879e1")
+	if err != nil {
+		t.Errorf("error creating did: %v", err)
+	}
+	docPubKey.ID = signerDid
+	docPubKey.Controller = did.CopyDID(signerDid)
+	didDoc, err := did.InitializeNewDocument(signerDid, docPubKey, true, true)
+	if err != nil {
+		t.Errorf("error making the did doc: %v", err)
+	}
+	if err := didService.SaveDocument(didDoc); err != nil {
+		t.Errorf("error saving the did doc: %v", err)
+	}
+
+	// Create the DID tree
+	pubBytes, _ := hex.DecodeString(pub)
+	ecdsaPubkey, _ := crypto.UnmarshalPubkey(pubBytes)
+	err = claimService.CreateTreeForDID(&didDoc.ID, ecdsaPubkey)
+	if err != nil {
+		t.Errorf("problem creating did tree: %v", err)
+	}
+
+	// Claim content 1
+	cred := makeContentCredential(&didDoc.ID)
+	addProof(cred, didDoc.PublicKeys[0].ID)
+	err = claimService.ClaimContent(cred)
+	if err != nil {
+		t.Errorf("problem creating content claim: %v", err)
+	}
+
+	listDidClaims, err := claimService.GetMerkleTreeClaimsForDid(&didDoc.ID)
+	if err != nil {
+		t.Errorf("error retrieving claims from did tree: %v", err)
+	}
+
+	contentCreds, err := claimService.ClaimsToContentCredentials(listDidClaims)
+	if err != nil {
+		t.Errorf("error converting claims to content creds: %v", err)
+	}
+
+	if len(listDidClaims) == 2 && len(contentCreds) != 1 {
+		t.Errorf("should have filtered down to 1 content cred from 2 claims")
+	}
+}

--- a/pkg/claims/service_test.go
+++ b/pkg/claims/service_test.go
@@ -238,7 +238,12 @@ func TestClaimsToContentCredentials(t *testing.T) {
 	}
 
 	// Create a DID identity
-	pub := "049691d8097f07afb7068a971ba500abd30b2ef763240bc56bf021ff592ed08446b7d23df1a5a043e7472d8954764f3fd39fbf992517e9c61ba10afee1965391e6"
+	key, err := crypto.HexToECDSA("79156abe7fe2fd433dc9df969286b96666489bac508612d0e16593e944c4f69f")
+	if err != nil {
+		t.Fatalf("should be able to make a key")
+	}
+	pubBytes := crypto.FromECDSAPub(&key.PublicKey)
+	pub := hex.EncodeToString(pubBytes)
 	docPubKey := &did.DocPublicKey{
 		Type:         linkeddata.SuiteTypeSecp256k1Verification,
 		PublicKeyHex: &pub,
@@ -258,7 +263,6 @@ func TestClaimsToContentCredentials(t *testing.T) {
 	}
 
 	// Create the DID tree
-	pubBytes, _ := hex.DecodeString(pub)
 	ecdsaPubkey, _ := crypto.UnmarshalPubkey(pubBytes)
 	err = claimService.CreateTreeForDID(&didDoc.ID, ecdsaPubkey)
 	if err != nil {
@@ -267,7 +271,7 @@ func TestClaimsToContentCredentials(t *testing.T) {
 
 	// Claim content 1
 	cred := makeContentCredential(&didDoc.ID)
-	addProof(cred, didDoc.PublicKeys[0].ID)
+	_ = addProof(cred, didDoc.PublicKeys[0].ID, key)
 	err = claimService.ClaimContent(cred)
 	if err != nil {
 		t.Errorf("problem creating content claim: %v", err)

--- a/pkg/did/helpers.go
+++ b/pkg/did/helpers.go
@@ -132,7 +132,7 @@ func ValidDocPublicKey(pk *DocPublicKey) bool {
 // LDSuiteTypeSecp256k1Verification
 func KeyFromType(pk *DocPublicKey) (*string, error) {
 	// Supports only Secp256k1 hex keys for now
-	// TODO(PN): Add more support here based on our needs
+	// NOTE(PN): Add more support here based on our needs
 	switch pk.Type {
 	case linkeddata.SuiteTypeSecp256k1Verification:
 		if pk.PublicKeyHex == nil || *pk.PublicKeyHex == "" {

--- a/pkg/did/model.go
+++ b/pkg/did/model.go
@@ -465,7 +465,7 @@ type DocService struct {
 	ServiceEndpointLD  map[string]interface{} `json:"-"`
 }
 
-// PopulateServiceEndpointVals populate the ServiceEndpointURI or ServiceEdnpointLD
+// PopulateServiceEndpointVals populate the ServiceEndpointURI or ServiceEndpointLD
 // based on the ServiceEndpoint interface{} value.
 func (s *DocService) PopulateServiceEndpointVals() error {
 	// Validate types for service endpoint.  Can either be a string (URI)

--- a/pkg/did/model.go
+++ b/pkg/did/model.go
@@ -171,11 +171,16 @@ func (d *Document) AddPublicKey(pk *DocPublicKey, addRefToAuth bool, addFragment
 
 // GetPublicKeyFromFragment returns the public key doc with the given fragment if it exists
 func (d *Document) GetPublicKeyFromFragment(fragment string) (*DocPublicKey, error) {
+	if d.PublicKeys == nil {
+		return nil, errors.New("DID does not have any public keys")
+	}
+
 	for _, v := range d.PublicKeys {
 		if v.ID.Fragment == fragment {
 			return &v, nil
 		}
 	}
+
 	return nil, errors.New("DID does not have a key that matches the fragment")
 }
 
@@ -476,7 +481,7 @@ func (s *DocService) PopulateServiceEndpointVals() error {
 		s.ServiceEndpointURI = &val
 	case map[string]interface{}:
 		// valid type
-		// TODO: do more for validation of JSON-LD
+		// XXX(PN): do more for validation of JSON-LD
 		s.ServiceEndpointLD = val
 	default:
 		return errors.Errorf("invalid type for service endpoint value: %T", val)

--- a/pkg/did/service.go
+++ b/pkg/did/service.go
@@ -64,6 +64,11 @@ func (s *Service) GetKeyFromDIDDocument(did *didlib.DID) (*DocPublicKey, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	if doc == nil {
+		return nil, errors.New("no did document found")
+	}
+
 	return doc.GetPublicKeyFromFragment(fragment)
 }
 

--- a/pkg/did/service.go
+++ b/pkg/did/service.go
@@ -52,15 +52,17 @@ func (s *Service) GetDocumentFromDID(did *didlib.DID) (*Document, error) {
 	return doc, nil
 }
 
-// GetKeyFromDIDDocument returns a public key document froma a did with a fragment if it can be found
+// GetKeyFromDIDDocument returns a public key document from a did with a fragment if it can be found
 // errors if fragment is empty
 func (s *Service) GetKeyFromDIDDocument(did *didlib.DID) (*DocPublicKey, error) {
-	fragment := did.Fragment
+	// Make copy to avoid side-effects to altering by reference
+	d := CopyDID(did)
+	fragment := d.Fragment
 	if fragment == "" {
 		return nil, errors.New("no fragment on did")
 	}
-	did.Fragment = ""
-	doc, err := s.GetDocumentFromDID(did)
+	d.Fragment = ""
+	doc, err := s.GetDocumentFromDID(d)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graphql/claim.graphql
+++ b/pkg/graphql/claim.graphql
@@ -4,9 +4,11 @@ extend type Query {
 	claimGet(in: ClaimGetRequestInput): ClaimGetResponse
 }
 
-# extend type Mutation {
-# 	claimSave(in: ClaimSaveRequestInput): ClaimSaveResponse
-# }
+extend type Mutation {
+	claimSave(in: ClaimSaveRequestInput): ClaimSaveResponse
+}
+
+## Inputs
 
 input ClaimGetRequestInput {
 	did: String!
@@ -17,16 +19,67 @@ type ClaimGetResponse {
 	claimsRaw: [String!]
 }
 
-# input ClaimSaveRequestInput {
-# 	context: [String!]
-# 	type: [String!]
-# 	credentialSubject: CredentialSubject
-# }
+input ClaimSaveRequestInput {
+	claim: ClaimInput
+	claimJson: String
+}
 
-# type ClaimSaveResponse {
-# 	claim: Claim!
-# 	claimRaw: String!
-# }
+input ClaimInput {
+	context: [String!]!
+	type: [String!]!
+	credentialSubject: ClaimCredentialSubjectInput!
+	issuer: String!
+	holder: String!
+	credentialSchema: ClaimCredentialSchemaInput!
+	issuanceDate: String!
+	proof: LinkedDataProofInput!
+}
+
+input ClaimCredentialSubjectInput {
+	id: String!
+	metadata: ArticleMetadataInput!
+}
+
+input ClaimCredentialSchemaInput {
+	id: String!
+	type: String!
+}
+
+input ArticleMetadataInput {
+	title: String
+	revisionContentHash: String
+	revisionContentURL: String
+	canonicalURL: String
+	slug: String
+	description: String
+	contributors: [ArticleMetadataContributorInput]
+	images: [ArticleMetadataImageInput]
+	tags: [String]
+	primaryTag: String
+	revisionDate: String
+	originalPublishDate: String
+	Opinion: Boolean
+	civilSchemaVersion: String
+}
+
+input ArticleMetadataContributorInput {
+	role: String
+	name: String
+}
+
+input ArticleMetadataImageInput {
+	url: String
+	hash: String
+	h: Int
+	w: Int
+}
+
+type ClaimSaveResponse {
+	claim: Claim!
+	claimRaw: String!
+}
+
+## Types
 
 type Claim {
 	context: [String!]!
@@ -34,6 +87,7 @@ type Claim {
 	credentialSubject: ClaimCredentialSubject!
 	issuer: String!
 	holder: String!
+	credentialSchema: ClaimCredentialSchema!
 	issuanceDate: String!
 	proof: LinkedDataProof!
 }
@@ -73,6 +127,6 @@ type ArticleMetadataContributor {
 type ArticleMetadataImage {
 	url: String
 	hash: String
-	height: Int
-	width: Int
+	h: Int
+	w: Int
 }

--- a/pkg/graphql/claim.graphql
+++ b/pkg/graphql/claim.graphql
@@ -24,6 +24,11 @@ input ClaimSaveRequestInput {
 	claimJson: String
 }
 
+type ClaimSaveResponse {
+	claim: Claim!
+	claimRaw: String!
+}
+
 input ClaimInput {
 	context: [String!]!
 	type: [String!]!
@@ -72,11 +77,6 @@ input ArticleMetadataImageInput {
 	hash: String
 	h: Int
 	w: Int
-}
-
-type ClaimSaveResponse {
-	claim: Claim!
-	claimRaw: String!
 }
 
 ## Types

--- a/pkg/graphql/claim.graphql
+++ b/pkg/graphql/claim.graphql
@@ -4,16 +4,75 @@ extend type Query {
 	claimGet(in: ClaimGetRequestInput): ClaimGetResponse
 }
 
-input ClaimGetRequestInput {
-	id: String
-}
+# extend type Mutation {
+# 	claimSave(in: ClaimSaveRequestInput): ClaimSaveResponse
+# }
 
-type Claim {
-	id: String
-	context: String
-	types: [String!]
+input ClaimGetRequestInput {
+	did: String!
 }
 
 type ClaimGetResponse {
-	claim: Claim
+	claims: [Claim!]
+	claimsRaw: [String!]
+}
+
+# input ClaimSaveRequestInput {
+# 	context: [String!]
+# 	type: [String!]
+# 	credentialSubject: CredentialSubject
+# }
+
+# type ClaimSaveResponse {
+# 	claim: Claim!
+# 	claimRaw: String!
+# }
+
+type Claim {
+	context: [String!]!
+	type: [String!]!
+	credentialSubject: ClaimCredentialSubject!
+	issuer: String!
+	holder: String!
+	issuanceDate: String!
+	proof: LinkedDataProof!
+}
+
+type ClaimCredentialSubject {
+	id: String!
+	metadata: ArticleMetadata!
+}
+
+type ClaimCredentialSchema {
+	id: String!
+	type: String!
+}
+
+type ArticleMetadata {
+	title: String
+	revisionContentHash: String
+	revisionContentURL: String
+	canonicalURL: String
+	slug: String
+	description: String
+	contributors: [ArticleMetadataContributor]
+	images: [ArticleMetadataImage]
+	tags: [String]
+	primaryTag: String
+	revisionDate: String
+	originalPublishDate: String
+	Opinion: Boolean
+	civilSchemaVersion: String
+}
+
+type ArticleMetadataContributor {
+	role: String
+	name: String
+}
+
+type ArticleMetadataImage {
+	url: String
+	hash: String
+	height: Int
+	width: Int
 }

--- a/pkg/graphql/claim_resolver.go
+++ b/pkg/graphql/claim_resolver.go
@@ -3,10 +3,13 @@ package graphql
 import (
 	"context"
 
+	log "github.com/golang/glog"
 	didlib "github.com/ockam-network/did"
+
 	"github.com/pkg/errors"
 
 	"github.com/joincivil/go-common/pkg/article"
+	"github.com/joincivil/id-hub/pkg/auth"
 	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/utils"
 )
@@ -49,6 +52,13 @@ func (r *queryResolver) ClaimGet(ctx context.Context, in *ClaimGetRequestInput) 
 func (r *mutationResolver) ClaimSave(ctx context.Context, in *ClaimSaveRequestInput) (
 	*ClaimSaveResponse, error) {
 	var err error
+
+	// Auth needed here, DID owner only
+	authErr := auth.ForContext(ctx, r.DidService, nil)
+	if authErr != nil {
+		log.Infof("Access denied err: %v", authErr)
+		return nil, ErrAccessDenied
+	}
 
 	cc, err := InputClaimToContentCredential(in)
 	if err != nil {

--- a/pkg/graphql/claim_resolver.go
+++ b/pkg/graphql/claim_resolver.go
@@ -2,9 +2,84 @@ package graphql
 
 import (
 	"context"
+
+	didlib "github.com/ockam-network/did"
+	"github.com/pkg/errors"
+
+	"github.com/joincivil/go-common/pkg/article"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
+	"github.com/joincivil/id-hub/pkg/utils"
 )
+
+// ResolverRoot
+
+// ArticleMetadata returns the resolver for article metadata
+func (r *Resolver) ArticleMetadata() ArticleMetadataResolver {
+	return &articleMetadataResolver{r}
+}
+
+// ArticleMetadataImage returns resolver for metadata images
+func (r *Resolver) ArticleMetadataImage() ArticleMetadataImageResolver {
+	return &articleMetadataImageResolver{r}
+}
+
+// Claim returns the resolver for claims
+func (r *Resolver) Claim() ClaimResolver {
+	return &claimResolver{r}
+}
+
+// Queries
 
 func (r *queryResolver) ClaimGet(ctx context.Context, in *ClaimGetRequestInput) (
 	*ClaimGetResponse, error) {
-	return nil, nil
+	d, err := didlib.Parse(in.Did)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing did in claim get")
+	}
+	clms, err := r.ClaimService.GetMerkleTreeClaimsForDid(d)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting claims in claim get")
+	}
+
+	creds, err := r.ClaimService.ClaimsToContentCredentials(clms)
+	if err != nil {
+		return nil, errors.Wrap(err, "error converting claims to creds")
+	}
+
+	return &ClaimGetResponse{Claims: creds}, nil
+}
+
+// Claim Resolvers
+
+type articleMetadataResolver struct{ *Resolver }
+
+func (r *articleMetadataResolver) RevisionDate(ctx context.Context, obj *article.Metadata) (*string, error) {
+	opd := obj.RevisionDate.Format("2006-01-02T15:04:05Z")
+	return utils.StrToPtr(opd), nil
+}
+func (r *articleMetadataResolver) OriginalPublishDate(ctx context.Context, obj *article.Metadata) (*string, error) {
+	opd := obj.OriginalPublishDate.Format("2006-01-02T15:04:05Z")
+	return utils.StrToPtr(opd), nil
+}
+
+type articleMetadataImageResolver struct{ *Resolver }
+
+func (r *articleMetadataImageResolver) Height(ctx context.Context, obj *article.Image) (*int, error) {
+	return utils.IntToPtr(obj.H), nil
+}
+func (r *articleMetadataImageResolver) Width(ctx context.Context, obj *article.Image) (*int, error) {
+	return utils.IntToPtr(obj.W), nil
+}
+
+type claimResolver struct{ *Resolver }
+
+func (r *claimResolver) Type(ctx context.Context, obj *claimsstore.ContentCredential) ([]string, error) {
+	ts := make([]string, len(obj.Type))
+	for ind, val := range obj.Type {
+		ts[ind] = string(val)
+	}
+	return ts, nil
+}
+func (r *claimResolver) IssuanceDate(ctx context.Context, obj *claimsstore.ContentCredential) (string, error) {
+	return obj.IssuanceDate.Format("2006-01-02T15:04:05Z"), nil
 }

--- a/pkg/graphql/did_resolver.go
+++ b/pkg/graphql/did_resolver.go
@@ -63,9 +63,16 @@ func (r *mutationResolver) DidSave(ctx context.Context, in *DidSaveRequestInput)
 	}
 
 	// Auth needed here, DID owner only
-	authErr := auth.ForContext(ctx, r.DidService, pks)
+	fcd, authErr := auth.ForContext(ctx, r.DidService, pks)
 	if authErr != nil {
 		log.Infof("Access denied err: %v", authErr)
+		return nil, ErrAccessDenied
+	}
+
+	// Auth to ensure the requestor did matches the doc did.
+	if in.Did != nil && *in.Did != fcd.Did {
+		log.Infof("Access denied, requestor did does not match incoming did: %v, %v",
+			in.Did, fcd.Did)
 		return nil, ErrAccessDenied
 	}
 

--- a/pkg/graphql/exec_gen.go
+++ b/pkg/graphql/exec_gen.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
+	"github.com/joincivil/go-common/pkg/article"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/did"
 	"github.com/joincivil/id-hub/pkg/linkeddata"
 	"github.com/joincivil/id-hub/pkg/utils"
@@ -38,6 +40,9 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	ArticleMetadata() ArticleMetadataResolver
+	ArticleMetadataImage() ArticleMetadataImageResolver
+	Claim() ClaimResolver
 	DidDocAuthentication() DidDocAuthenticationResolver
 	DidDocPublicKey() DidDocPublicKeyResolver
 	DidDocService() DidDocServiceResolver
@@ -50,14 +55,58 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	ArticleMetadata struct {
+		CanonicalURL        func(childComplexity int) int
+		CivilSchemaVersion  func(childComplexity int) int
+		Contributors        func(childComplexity int) int
+		Description         func(childComplexity int) int
+		Images              func(childComplexity int) int
+		Opinion             func(childComplexity int) int
+		OriginalPublishDate func(childComplexity int) int
+		PrimaryTag          func(childComplexity int) int
+		RevisionContentHash func(childComplexity int) int
+		RevisionContentURL  func(childComplexity int) int
+		RevisionDate        func(childComplexity int) int
+		Slug                func(childComplexity int) int
+		Tags                func(childComplexity int) int
+		Title               func(childComplexity int) int
+	}
+
+	ArticleMetadataContributor struct {
+		Name func(childComplexity int) int
+		Role func(childComplexity int) int
+	}
+
+	ArticleMetadataImage struct {
+		Hash   func(childComplexity int) int
+		Height func(childComplexity int) int
+		URL    func(childComplexity int) int
+		Width  func(childComplexity int) int
+	}
+
 	Claim struct {
-		Context func(childComplexity int) int
-		ID      func(childComplexity int) int
-		Types   func(childComplexity int) int
+		Context           func(childComplexity int) int
+		CredentialSubject func(childComplexity int) int
+		Holder            func(childComplexity int) int
+		IssuanceDate      func(childComplexity int) int
+		Issuer            func(childComplexity int) int
+		Proof             func(childComplexity int) int
+		Type              func(childComplexity int) int
+	}
+
+	ClaimCredentialSchema struct {
+		ID   func(childComplexity int) int
+		Type func(childComplexity int) int
+	}
+
+	ClaimCredentialSubject struct {
+		ID       func(childComplexity int) int
+		Metadata func(childComplexity int) int
 	}
 
 	ClaimGetResponse struct {
-		Claim func(childComplexity int) int
+		Claims    func(childComplexity int) int
+		ClaimsRaw func(childComplexity int) int
 	}
 
 	DidDocAuthentication struct {
@@ -129,6 +178,19 @@ type ComplexityRoot struct {
 	}
 }
 
+type ArticleMetadataResolver interface {
+	RevisionDate(ctx context.Context, obj *article.Metadata) (*string, error)
+	OriginalPublishDate(ctx context.Context, obj *article.Metadata) (*string, error)
+}
+type ArticleMetadataImageResolver interface {
+	Height(ctx context.Context, obj *article.Image) (*int, error)
+	Width(ctx context.Context, obj *article.Image) (*int, error)
+}
+type ClaimResolver interface {
+	Type(ctx context.Context, obj *claimsstore.ContentCredential) ([]string, error)
+
+	IssuanceDate(ctx context.Context, obj *claimsstore.ContentCredential) (string, error)
+}
 type DidDocAuthenticationResolver interface {
 	PublicKey(ctx context.Context, obj *did.DocAuthenicationWrapper) (*did.DocPublicKey, error)
 }
@@ -172,6 +234,146 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
+	case "ArticleMetadata.canonicalURL":
+		if e.complexity.ArticleMetadata.CanonicalURL == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.CanonicalURL(childComplexity), true
+
+	case "ArticleMetadata.civilSchemaVersion":
+		if e.complexity.ArticleMetadata.CivilSchemaVersion == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.CivilSchemaVersion(childComplexity), true
+
+	case "ArticleMetadata.contributors":
+		if e.complexity.ArticleMetadata.Contributors == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Contributors(childComplexity), true
+
+	case "ArticleMetadata.description":
+		if e.complexity.ArticleMetadata.Description == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Description(childComplexity), true
+
+	case "ArticleMetadata.images":
+		if e.complexity.ArticleMetadata.Images == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Images(childComplexity), true
+
+	case "ArticleMetadata.Opinion":
+		if e.complexity.ArticleMetadata.Opinion == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Opinion(childComplexity), true
+
+	case "ArticleMetadata.originalPublishDate":
+		if e.complexity.ArticleMetadata.OriginalPublishDate == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.OriginalPublishDate(childComplexity), true
+
+	case "ArticleMetadata.primaryTag":
+		if e.complexity.ArticleMetadata.PrimaryTag == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.PrimaryTag(childComplexity), true
+
+	case "ArticleMetadata.revisionContentHash":
+		if e.complexity.ArticleMetadata.RevisionContentHash == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.RevisionContentHash(childComplexity), true
+
+	case "ArticleMetadata.revisionContentURL":
+		if e.complexity.ArticleMetadata.RevisionContentURL == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.RevisionContentURL(childComplexity), true
+
+	case "ArticleMetadata.revisionDate":
+		if e.complexity.ArticleMetadata.RevisionDate == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.RevisionDate(childComplexity), true
+
+	case "ArticleMetadata.slug":
+		if e.complexity.ArticleMetadata.Slug == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Slug(childComplexity), true
+
+	case "ArticleMetadata.tags":
+		if e.complexity.ArticleMetadata.Tags == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Tags(childComplexity), true
+
+	case "ArticleMetadata.title":
+		if e.complexity.ArticleMetadata.Title == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadata.Title(childComplexity), true
+
+	case "ArticleMetadataContributor.name":
+		if e.complexity.ArticleMetadataContributor.Name == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataContributor.Name(childComplexity), true
+
+	case "ArticleMetadataContributor.role":
+		if e.complexity.ArticleMetadataContributor.Role == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataContributor.Role(childComplexity), true
+
+	case "ArticleMetadataImage.hash":
+		if e.complexity.ArticleMetadataImage.Hash == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataImage.Hash(childComplexity), true
+
+	case "ArticleMetadataImage.height":
+		if e.complexity.ArticleMetadataImage.Height == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataImage.Height(childComplexity), true
+
+	case "ArticleMetadataImage.url":
+		if e.complexity.ArticleMetadataImage.URL == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataImage.URL(childComplexity), true
+
+	case "ArticleMetadataImage.width":
+		if e.complexity.ArticleMetadataImage.Width == nil {
+			break
+		}
+
+		return e.complexity.ArticleMetadataImage.Width(childComplexity), true
+
 	case "Claim.context":
 		if e.complexity.Claim.Context == nil {
 			break
@@ -179,26 +381,89 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Claim.Context(childComplexity), true
 
-	case "Claim.id":
-		if e.complexity.Claim.ID == nil {
+	case "Claim.credentialSubject":
+		if e.complexity.Claim.CredentialSubject == nil {
 			break
 		}
 
-		return e.complexity.Claim.ID(childComplexity), true
+		return e.complexity.Claim.CredentialSubject(childComplexity), true
 
-	case "Claim.types":
-		if e.complexity.Claim.Types == nil {
+	case "Claim.holder":
+		if e.complexity.Claim.Holder == nil {
 			break
 		}
 
-		return e.complexity.Claim.Types(childComplexity), true
+		return e.complexity.Claim.Holder(childComplexity), true
 
-	case "ClaimGetResponse.claim":
-		if e.complexity.ClaimGetResponse.Claim == nil {
+	case "Claim.issuanceDate":
+		if e.complexity.Claim.IssuanceDate == nil {
 			break
 		}
 
-		return e.complexity.ClaimGetResponse.Claim(childComplexity), true
+		return e.complexity.Claim.IssuanceDate(childComplexity), true
+
+	case "Claim.issuer":
+		if e.complexity.Claim.Issuer == nil {
+			break
+		}
+
+		return e.complexity.Claim.Issuer(childComplexity), true
+
+	case "Claim.proof":
+		if e.complexity.Claim.Proof == nil {
+			break
+		}
+
+		return e.complexity.Claim.Proof(childComplexity), true
+
+	case "Claim.type":
+		if e.complexity.Claim.Type == nil {
+			break
+		}
+
+		return e.complexity.Claim.Type(childComplexity), true
+
+	case "ClaimCredentialSchema.id":
+		if e.complexity.ClaimCredentialSchema.ID == nil {
+			break
+		}
+
+		return e.complexity.ClaimCredentialSchema.ID(childComplexity), true
+
+	case "ClaimCredentialSchema.type":
+		if e.complexity.ClaimCredentialSchema.Type == nil {
+			break
+		}
+
+		return e.complexity.ClaimCredentialSchema.Type(childComplexity), true
+
+	case "ClaimCredentialSubject.id":
+		if e.complexity.ClaimCredentialSubject.ID == nil {
+			break
+		}
+
+		return e.complexity.ClaimCredentialSubject.ID(childComplexity), true
+
+	case "ClaimCredentialSubject.metadata":
+		if e.complexity.ClaimCredentialSubject.Metadata == nil {
+			break
+		}
+
+		return e.complexity.ClaimCredentialSubject.Metadata(childComplexity), true
+
+	case "ClaimGetResponse.claims":
+		if e.complexity.ClaimGetResponse.Claims == nil {
+			break
+		}
+
+		return e.complexity.ClaimGetResponse.Claims(childComplexity), true
+
+	case "ClaimGetResponse.claimsRaw":
+		if e.complexity.ClaimGetResponse.ClaimsRaw == nil {
+			break
+		}
+
+		return e.complexity.ClaimGetResponse.ClaimsRaw(childComplexity), true
 
 	case "DidDocAuthentication.idOnly":
 		if e.complexity.DidDocAuthentication.IDOnly == nil {
@@ -580,19 +845,79 @@ extend type Query {
 	claimGet(in: ClaimGetRequestInput): ClaimGetResponse
 }
 
-input ClaimGetRequestInput {
-	id: String
-}
+# extend type Mutation {
+# 	claimSave(in: ClaimSaveRequestInput): ClaimSaveResponse
+# }
 
-type Claim {
-	id: String
-	context: String
-	types: [String!]
+input ClaimGetRequestInput {
+	did: String!
 }
 
 type ClaimGetResponse {
-	claim: Claim
-}`},
+	claims: [Claim!]
+	claimsRaw: [String!]
+}
+
+# input ClaimSaveRequestInput {
+# 	context: [String!]
+# 	type: [String!]
+# 	credentialSubject: CredentialSubject
+# }
+
+# type ClaimSaveResponse {
+# 	claim: Claim!
+# 	claimRaw: String!
+# }
+
+type Claim {
+	context: [String!]!
+	type: [String!]!
+	credentialSubject: ClaimCredentialSubject!
+	issuer: String!
+	holder: String!
+	issuanceDate: String!
+	proof: LinkedDataProof!
+}
+
+type ClaimCredentialSubject {
+	id: String!
+	metadata: ArticleMetadata!
+}
+
+type ClaimCredentialSchema {
+	id: String!
+	type: String!
+}
+
+type ArticleMetadata {
+	title: String
+	revisionContentHash: String
+	revisionContentURL: String
+	canonicalURL: String
+	slug: String
+	description: String
+	contributors: [ArticleMetadataContributor]
+	images: [ArticleMetadataImage]
+	tags: [String]
+	primaryTag: String
+	revisionDate: String
+	originalPublishDate: String
+	Opinion: Boolean
+	civilSchemaVersion: String
+}
+
+type ArticleMetadataContributor {
+	role: String
+	name: String
+}
+
+type ArticleMetadataImage {
+	url: String
+	hash: String
+	height: Int
+	width: Int
+}
+`},
 	&ast.Source{Name: "did.graphql", Input: `# DID specific schema
 
 extend type Mutation {
@@ -807,7 +1132,7 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _Claim_id(ctx context.Context, field graphql.CollectedField, obj *Claim) (ret graphql.Marshaler) {
+func (ec *executionContext) _ArticleMetadata_title(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -817,7 +1142,7 @@ func (ec *executionContext) _Claim_id(ctx context.Context, field graphql.Collect
 		ec.Tracer.EndFieldExecution(ctx)
 	}()
 	rctx := &graphql.ResolverContext{
-		Object:   "Claim",
+		Object:   "ArticleMetadata",
 		Field:    field,
 		Args:     nil,
 		IsMethod: false,
@@ -826,7 +1151,347 @@ func (ec *executionContext) _Claim_id(ctx context.Context, field graphql.Collect
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_revisionContentHash(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RevisionContentHash, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_revisionContentURL(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RevisionContentURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_canonicalURL(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CanonicalURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_slug(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Slug, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_description(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_contributors(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Contributors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]article.Contributor)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOArticleMetadataContributor2ᚕgithubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐContributor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_images(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Images, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]article.Image)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOArticleMetadataImage2ᚕgithubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐImage(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_tags(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Tags, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2ᚕstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_primaryTag(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrimaryTag, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_revisionDate(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ArticleMetadata().RevisionDate(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -841,7 +1506,313 @@ func (ec *executionContext) _Claim_id(ctx context.Context, field graphql.Collect
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Claim_context(ctx context.Context, field graphql.CollectedField, obj *Claim) (ret graphql.Marshaler) {
+func (ec *executionContext) _ArticleMetadata_originalPublishDate(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ArticleMetadata().OriginalPublishDate(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_Opinion(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Opinion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadata_civilSchemaVersion(ctx context.Context, field graphql.CollectedField, obj *article.Metadata) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadata",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CivilSchemaVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataContributor_role(ctx context.Context, field graphql.CollectedField, obj *article.Contributor) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataContributor",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Role, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataContributor_name(ctx context.Context, field graphql.CollectedField, obj *article.Contributor) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataContributor",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataImage_url(ctx context.Context, field graphql.CollectedField, obj *article.Image) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataImage",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataImage_hash(ctx context.Context, field graphql.CollectedField, obj *article.Image) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataImage",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Hash, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataImage_height(ctx context.Context, field graphql.CollectedField, obj *article.Image) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataImage",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ArticleMetadataImage().Height(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ArticleMetadataImage_width(ctx context.Context, field graphql.CollectedField, obj *article.Image) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ArticleMetadataImage",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ArticleMetadataImage().Width(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Claim_context(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -867,15 +1838,55 @@ func (ec *executionContext) _Claim_context(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.([]string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Claim_types(ctx context.Context, field graphql.CollectedField, obj *Claim) (ret graphql.Marshaler) {
+func (ec *executionContext) _Claim_type(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Claim",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Claim().Type(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2ᚕstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Claim_credentialSubject(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -894,22 +1905,321 @@ func (ec *executionContext) _Claim_types(ctx context.Context, field graphql.Coll
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Types, nil
+		return obj.CredentialSubject, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.(claimsstore.ContentCredentialSubject)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOString2ᚕstring(ctx, field.Selections, res)
+	return ec.marshalNClaimCredentialSubject2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredentialSubject(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _ClaimGetResponse_claim(ctx context.Context, field graphql.CollectedField, obj *ClaimGetResponse) (ret graphql.Marshaler) {
+func (ec *executionContext) _Claim_issuer(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Claim",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Issuer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Claim_holder(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Claim",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Holder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Claim_issuanceDate(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Claim",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Claim().IssuanceDate(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Claim_proof(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredential) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Claim",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Proof, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(linkeddata.Proof)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNLinkedDataProof2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋlinkeddataᚐProof(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimCredentialSchema_id(ctx context.Context, field graphql.CollectedField, obj *claimsstore.CredentialSchema) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ClaimCredentialSchema",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimCredentialSchema_type(ctx context.Context, field graphql.CollectedField, obj *claimsstore.CredentialSchema) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ClaimCredentialSchema",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimCredentialSubject_id(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredentialSubject) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ClaimCredentialSubject",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimCredentialSubject_metadata(ctx context.Context, field graphql.CollectedField, obj *claimsstore.ContentCredentialSubject) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ClaimCredentialSubject",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Metadata, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(article.Metadata)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNArticleMetadata2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐMetadata(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimGetResponse_claims(ctx context.Context, field graphql.CollectedField, obj *ClaimGetResponse) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -928,7 +2238,7 @@ func (ec *executionContext) _ClaimGetResponse_claim(ctx context.Context, field g
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Claim, nil
+		return obj.Claims, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -937,10 +2247,44 @@ func (ec *executionContext) _ClaimGetResponse_claim(ctx context.Context, field g
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*Claim)
+	res := resTmp.([]*claimsstore.ContentCredential)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOClaim2ᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋgraphqlᚐClaim(ctx, field.Selections, res)
+	return ec.marshalOClaim2ᚕᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredential(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ClaimGetResponse_claimsRaw(ctx context.Context, field graphql.CollectedField, obj *ClaimGetResponse) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "ClaimGetResponse",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClaimsRaw(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2ᚕstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _DidDocAuthentication_publicKey(ctx context.Context, field graphql.CollectedField, obj *did.DocAuthenicationWrapper) (ret graphql.Marshaler) {
@@ -3596,9 +4940,9 @@ func (ec *executionContext) unmarshalInputClaimGetRequestInput(ctx context.Conte
 
 	for k, v := range asMap {
 		switch k {
-		case "id":
+		case "did":
 			var err error
-			it.ID, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Did, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -3862,9 +5206,151 @@ func (ec *executionContext) unmarshalInputLinkedDataProofInput(ctx context.Conte
 
 // region    **************************** object.gotpl ****************************
 
+var articleMetadataImplementors = []string{"ArticleMetadata"}
+
+func (ec *executionContext) _ArticleMetadata(ctx context.Context, sel ast.SelectionSet, obj *article.Metadata) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, articleMetadataImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ArticleMetadata")
+		case "title":
+			out.Values[i] = ec._ArticleMetadata_title(ctx, field, obj)
+		case "revisionContentHash":
+			out.Values[i] = ec._ArticleMetadata_revisionContentHash(ctx, field, obj)
+		case "revisionContentURL":
+			out.Values[i] = ec._ArticleMetadata_revisionContentURL(ctx, field, obj)
+		case "canonicalURL":
+			out.Values[i] = ec._ArticleMetadata_canonicalURL(ctx, field, obj)
+		case "slug":
+			out.Values[i] = ec._ArticleMetadata_slug(ctx, field, obj)
+		case "description":
+			out.Values[i] = ec._ArticleMetadata_description(ctx, field, obj)
+		case "contributors":
+			out.Values[i] = ec._ArticleMetadata_contributors(ctx, field, obj)
+		case "images":
+			out.Values[i] = ec._ArticleMetadata_images(ctx, field, obj)
+		case "tags":
+			out.Values[i] = ec._ArticleMetadata_tags(ctx, field, obj)
+		case "primaryTag":
+			out.Values[i] = ec._ArticleMetadata_primaryTag(ctx, field, obj)
+		case "revisionDate":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ArticleMetadata_revisionDate(ctx, field, obj)
+				return res
+			})
+		case "originalPublishDate":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ArticleMetadata_originalPublishDate(ctx, field, obj)
+				return res
+			})
+		case "Opinion":
+			out.Values[i] = ec._ArticleMetadata_Opinion(ctx, field, obj)
+		case "civilSchemaVersion":
+			out.Values[i] = ec._ArticleMetadata_civilSchemaVersion(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var articleMetadataContributorImplementors = []string{"ArticleMetadataContributor"}
+
+func (ec *executionContext) _ArticleMetadataContributor(ctx context.Context, sel ast.SelectionSet, obj *article.Contributor) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, articleMetadataContributorImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ArticleMetadataContributor")
+		case "role":
+			out.Values[i] = ec._ArticleMetadataContributor_role(ctx, field, obj)
+		case "name":
+			out.Values[i] = ec._ArticleMetadataContributor_name(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var articleMetadataImageImplementors = []string{"ArticleMetadataImage"}
+
+func (ec *executionContext) _ArticleMetadataImage(ctx context.Context, sel ast.SelectionSet, obj *article.Image) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, articleMetadataImageImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ArticleMetadataImage")
+		case "url":
+			out.Values[i] = ec._ArticleMetadataImage_url(ctx, field, obj)
+		case "hash":
+			out.Values[i] = ec._ArticleMetadataImage_hash(ctx, field, obj)
+		case "height":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ArticleMetadataImage_height(ctx, field, obj)
+				return res
+			})
+		case "width":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ArticleMetadataImage_width(ctx, field, obj)
+				return res
+			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var claimImplementors = []string{"Claim"}
 
-func (ec *executionContext) _Claim(ctx context.Context, sel ast.SelectionSet, obj *Claim) graphql.Marshaler {
+func (ec *executionContext) _Claim(ctx context.Context, sel ast.SelectionSet, obj *claimsstore.ContentCredential) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.RequestContext, sel, claimImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -3873,12 +5359,123 @@ func (ec *executionContext) _Claim(ctx context.Context, sel ast.SelectionSet, ob
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Claim")
-		case "id":
-			out.Values[i] = ec._Claim_id(ctx, field, obj)
 		case "context":
 			out.Values[i] = ec._Claim_context(ctx, field, obj)
-		case "types":
-			out.Values[i] = ec._Claim_types(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "type":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Claim_type(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "credentialSubject":
+			out.Values[i] = ec._Claim_credentialSubject(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "issuer":
+			out.Values[i] = ec._Claim_issuer(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "holder":
+			out.Values[i] = ec._Claim_holder(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "issuanceDate":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Claim_issuanceDate(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "proof":
+			out.Values[i] = ec._Claim_proof(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var claimCredentialSchemaImplementors = []string{"ClaimCredentialSchema"}
+
+func (ec *executionContext) _ClaimCredentialSchema(ctx context.Context, sel ast.SelectionSet, obj *claimsstore.CredentialSchema) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, claimCredentialSchemaImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ClaimCredentialSchema")
+		case "id":
+			out.Values[i] = ec._ClaimCredentialSchema_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "type":
+			out.Values[i] = ec._ClaimCredentialSchema_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var claimCredentialSubjectImplementors = []string{"ClaimCredentialSubject"}
+
+func (ec *executionContext) _ClaimCredentialSubject(ctx context.Context, sel ast.SelectionSet, obj *claimsstore.ContentCredentialSubject) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, claimCredentialSubjectImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ClaimCredentialSubject")
+		case "id":
+			out.Values[i] = ec._ClaimCredentialSubject_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "metadata":
+			out.Values[i] = ec._ClaimCredentialSubject_metadata(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3901,8 +5498,10 @@ func (ec *executionContext) _ClaimGetResponse(ctx context.Context, sel ast.Selec
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ClaimGetResponse")
-		case "claim":
-			out.Values[i] = ec._ClaimGetResponse_claim(ctx, field, obj)
+		case "claims":
+			out.Values[i] = ec._ClaimGetResponse_claims(ctx, field, obj)
+		case "claimsRaw":
+			out.Values[i] = ec._ClaimGetResponse_claimsRaw(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4556,6 +6155,10 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNArticleMetadata2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐMetadata(ctx context.Context, sel ast.SelectionSet, v article.Metadata) graphql.Marshaler {
+	return ec._ArticleMetadata(ctx, sel, &v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
 }
@@ -4568,6 +6171,24 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNClaim2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredential(ctx context.Context, sel ast.SelectionSet, v claimsstore.ContentCredential) graphql.Marshaler {
+	return ec._Claim(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNClaim2ᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredential(ctx context.Context, sel ast.SelectionSet, v *claimsstore.ContentCredential) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Claim(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNClaimCredentialSubject2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredentialSubject(ctx context.Context, sel ast.SelectionSet, v claimsstore.ContentCredentialSubject) graphql.Marshaler {
+	return ec._ClaimCredentialSubject(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNDidDocAuthentication2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋdidᚐDocAuthenicationWrapper(ctx context.Context, sel ast.SelectionSet, v did.DocAuthenicationWrapper) graphql.Marshaler {
@@ -4618,6 +6239,10 @@ func (ec *executionContext) unmarshalNDidDocServiceInput2ᚖgithubᚗcomᚋjoinc
 	return &res, err
 }
 
+func (ec *executionContext) marshalNLinkedDataProof2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋlinkeddataᚐProof(ctx context.Context, sel ast.SelectionSet, v linkeddata.Proof) graphql.Marshaler {
+	return ec._LinkedDataProof(ctx, sel, &v)
+}
+
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
 	return graphql.UnmarshalString(v)
 }
@@ -4630,6 +6255,35 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstring(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstring(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
@@ -4882,6 +6536,94 @@ func (ec *executionContext) marshalOAnyValue2ᚖgithubᚗcomᚋjoincivilᚋidᚑ
 	return v
 }
 
+func (ec *executionContext) marshalOArticleMetadataContributor2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐContributor(ctx context.Context, sel ast.SelectionSet, v article.Contributor) graphql.Marshaler {
+	return ec._ArticleMetadataContributor(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOArticleMetadataContributor2ᚕgithubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐContributor(ctx context.Context, sel ast.SelectionSet, v []article.Contributor) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOArticleMetadataContributor2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐContributor(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalOArticleMetadataImage2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐImage(ctx context.Context, sel ast.SelectionSet, v article.Image) graphql.Marshaler {
+	return ec._ArticleMetadataImage(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOArticleMetadataImage2ᚕgithubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐImage(ctx context.Context, sel ast.SelectionSet, v []article.Image) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOArticleMetadataImage2githubᚗcomᚋjoincivilᚋgoᚑcommonᚋpkgᚋarticleᚐImage(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
 }
@@ -4905,15 +6647,44 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return ec.marshalOBoolean2bool(ctx, sel, *v)
 }
 
-func (ec *executionContext) marshalOClaim2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋgraphqlᚐClaim(ctx context.Context, sel ast.SelectionSet, v Claim) graphql.Marshaler {
-	return ec._Claim(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalOClaim2ᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋgraphqlᚐClaim(ctx context.Context, sel ast.SelectionSet, v *Claim) graphql.Marshaler {
+func (ec *executionContext) marshalOClaim2ᚕᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredential(ctx context.Context, sel ast.SelectionSet, v []*claimsstore.ContentCredential) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return ec._Claim(ctx, sel, v)
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNClaim2ᚖgithubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋclaimsstoreᚐContentCredential(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
 }
 
 func (ec *executionContext) unmarshalOClaimGetRequestInput2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋgraphqlᚐClaimGetRequestInput(ctx context.Context, v interface{}) (ClaimGetRequestInput, error) {
@@ -5199,6 +6970,29 @@ func (ec *executionContext) marshalODidSaveResponse2ᚖgithubᚗcomᚋjoincivil�
 	return ec._DidSaveResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalOInt2int(ctx context.Context, v interface{}) (int, error) {
+	return graphql.UnmarshalInt(v)
+}
+
+func (ec *executionContext) marshalOInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	return graphql.MarshalInt(v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOInt2int(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec.marshalOInt2int(ctx, sel, *v)
+}
+
 func (ec *executionContext) marshalOLinkedDataProof2githubᚗcomᚋjoincivilᚋidᚑhubᚋpkgᚋlinkeddataᚐProof(ctx context.Context, sel ast.SelectionSet, v linkeddata.Proof) graphql.Marshaler {
 	return ec._LinkedDataProof(ctx, sel, &v)
 }
@@ -5242,7 +7036,7 @@ func (ec *executionContext) unmarshalOString2ᚕstring(ctx context.Context, v in
 	var err error
 	res := make([]string, len(vSlice))
 	for i := range vSlice {
-		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		res[i], err = ec.unmarshalOString2string(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -5256,7 +7050,7 @@ func (ec *executionContext) marshalOString2ᚕstring(ctx context.Context, sel as
 	}
 	ret := make(graphql.Array, len(v))
 	for i := range v {
-		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+		ret[i] = ec.marshalOString2string(ctx, sel, v[i])
 	}
 
 	return ret

--- a/pkg/graphql/gqlgen.yml
+++ b/pkg/graphql/gqlgen.yml
@@ -36,3 +36,24 @@ models:
   DidSaveResponse:
     model:
       - github.com/joincivil/id-hub/pkg/graphql.DidSaveResponse
+  Claim:
+    model:
+      - github.com/joincivil/id-hub/pkg/claimsstore.ContentCredential
+  ClaimCredentialSubject:
+    model:
+      - github.com/joincivil/id-hub/pkg/claimsstore.ContentCredentialSubject
+  ClaimCredentialSchema:
+    model:
+      - github.com/joincivil/id-hub/pkg/claimsstore.CredentialSchema
+  ClaimGetResponse:
+    model:
+      - github.com/joincivil/id-hub/pkg/graphql.ClaimGetResponse
+  ArticleMetadata:
+    model:
+      - github.com/joincivil/go-common/pkg/article.Metadata
+  ArticleMetadataContributor:
+    model:
+      - github.com/joincivil/go-common/pkg/article.Contributor
+  ArticleMetadataImage:
+    model:
+      - github.com/joincivil/go-common/pkg/article.Image

--- a/pkg/graphql/gqlgen.yml
+++ b/pkg/graphql/gqlgen.yml
@@ -48,6 +48,9 @@ models:
   ClaimGetResponse:
     model:
       - github.com/joincivil/id-hub/pkg/graphql.ClaimGetResponse
+  ClaimSaveResponse:
+    model:
+      - github.com/joincivil/id-hub/pkg/graphql.ClaimSaveResponse
   ArticleMetadata:
     model:
       - github.com/joincivil/go-common/pkg/article.Metadata

--- a/pkg/graphql/model.go
+++ b/pkg/graphql/model.go
@@ -62,17 +62,17 @@ func (d *ClaimGetResponse) ClaimsRaw() []string {
 }
 
 // ClaimSaveResponse represents the GraphQL response for ClaimSave
-// type ClaimSaveResponse struct {
-// 	Claim *claimsstore.ContentCredential `json:"claim"`
-// }
+type ClaimSaveResponse struct {
+	Claim *claimsstore.ContentCredential `json:"claim"`
+}
 
 // ClaimRaw returns the raw JSON string of the claim
-// func (d *ClaimSaveResponse) ClaimRaw() *string {
-// 	bys, err := json.Marshal(d.Claims)
-// 	if err != nil {
-// 		log.Errorf("Error marshalling claim: err: %v", err)
-// 		return nil
-// 	}
-// 	claimRaw := string(bys)
-// 	return &claimRaw
-// }
+func (d *ClaimSaveResponse) ClaimRaw() *string {
+	bys, err := json.Marshal(d.Claim)
+	if err != nil {
+		log.Errorf("Error marshalling claim: err: %v", err)
+		return nil
+	}
+	claimRaw := string(bys)
+	return &claimRaw
+}

--- a/pkg/graphql/model.go
+++ b/pkg/graphql/model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	log "github.com/golang/glog"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/did"
 )
 
@@ -38,3 +39,40 @@ func (d *DidSaveResponse) DocRaw() *string {
 	docRaw := string(bys)
 	return &docRaw
 }
+
+// ClaimGetResponse represents the GraphQL response for ClaimGet
+type ClaimGetResponse struct {
+	Claims []*claimsstore.ContentCredential `json:"claims"`
+}
+
+// ClaimsRaw returns the raw JSON string for the list of claims
+func (d *ClaimGetResponse) ClaimsRaw() []string {
+	clms := make([]string, len(d.Claims))
+
+	for ind, c := range d.Claims {
+		bys, err := json.Marshal(c)
+		if err != nil {
+			log.Errorf("Error marshalling claim: err: %v", err)
+			continue
+		}
+		clms[ind] = string(bys)
+	}
+
+	return clms
+}
+
+// ClaimSaveResponse represents the GraphQL response for ClaimSave
+// type ClaimSaveResponse struct {
+// 	Claim *claimsstore.ContentCredential `json:"claim"`
+// }
+
+// ClaimRaw returns the raw JSON string of the claim
+// func (d *ClaimSaveResponse) ClaimRaw() *string {
+// 	bys, err := json.Marshal(d.Claims)
+// 	if err != nil {
+// 		log.Errorf("Error marshalling claim: err: %v", err)
+// 		return nil
+// 	}
+// 	claimRaw := string(bys)
+// 	return &claimRaw
+// }

--- a/pkg/graphql/model_gen.go
+++ b/pkg/graphql/model_gen.go
@@ -8,18 +8,8 @@ import (
 	"github.com/joincivil/id-hub/pkg/utils"
 )
 
-type Claim struct {
-	ID      *string  `json:"id"`
-	Context *string  `json:"context"`
-	Types   []string `json:"types"`
-}
-
 type ClaimGetRequestInput struct {
-	ID *string `json:"id"`
-}
-
-type ClaimGetResponse struct {
-	Claim *Claim `json:"claim"`
+	Did string `json:"did"`
 }
 
 type DidDocAuthenticationInput struct {

--- a/pkg/graphql/model_gen.go
+++ b/pkg/graphql/model_gen.go
@@ -8,8 +8,63 @@ import (
 	"github.com/joincivil/id-hub/pkg/utils"
 )
 
+type ArticleMetadataContributorInput struct {
+	Role *string `json:"role"`
+	Name *string `json:"name"`
+}
+
+type ArticleMetadataImageInput struct {
+	URL  *string `json:"url"`
+	Hash *string `json:"hash"`
+	H    *int    `json:"h"`
+	W    *int    `json:"w"`
+}
+
+type ArticleMetadataInput struct {
+	Title               *string                            `json:"title"`
+	RevisionContentHash *string                            `json:"revisionContentHash"`
+	RevisionContentURL  *string                            `json:"revisionContentURL"`
+	CanonicalURL        *string                            `json:"canonicalURL"`
+	Slug                *string                            `json:"slug"`
+	Description         *string                            `json:"description"`
+	Contributors        []*ArticleMetadataContributorInput `json:"contributors"`
+	Images              []*ArticleMetadataImageInput       `json:"images"`
+	Tags                []*string                          `json:"tags"`
+	PrimaryTag          *string                            `json:"primaryTag"`
+	RevisionDate        *string                            `json:"revisionDate"`
+	OriginalPublishDate *string                            `json:"originalPublishDate"`
+	Opinion             *bool                              `json:"Opinion"`
+	CivilSchemaVersion  *string                            `json:"civilSchemaVersion"`
+}
+
+type ClaimCredentialSchemaInput struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type ClaimCredentialSubjectInput struct {
+	ID       string                `json:"id"`
+	Metadata *ArticleMetadataInput `json:"metadata"`
+}
+
 type ClaimGetRequestInput struct {
 	Did string `json:"did"`
+}
+
+type ClaimInput struct {
+	Context           []string                     `json:"context"`
+	Type              []string                     `json:"type"`
+	CredentialSubject *ClaimCredentialSubjectInput `json:"credentialSubject"`
+	Issuer            string                       `json:"issuer"`
+	Holder            string                       `json:"holder"`
+	CredentialSchema  *ClaimCredentialSchemaInput  `json:"credentialSchema"`
+	IssuanceDate      string                       `json:"issuanceDate"`
+	Proof             *LinkedDataProofInput        `json:"proof"`
+}
+
+type ClaimSaveRequestInput struct {
+	Claim     *ClaimInput `json:"claim"`
+	ClaimJSON *string     `json:"claimJson"`
 }
 
 type DidDocAuthenticationInput struct {

--- a/pkg/graphql/resolver.go
+++ b/pkg/graphql/resolver.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 
+	"github.com/joincivil/id-hub/pkg/claims"
 	"github.com/joincivil/id-hub/pkg/did"
 )
 
@@ -12,7 +13,8 @@ const (
 
 // Resolver is the main GraphQL resolver
 type Resolver struct {
-	DidService *did.Service
+	DidService   *did.Service
+	ClaimService *claims.Service
 }
 
 // Version returns the version of the GraphQL API

--- a/pkg/graphql/resolver.go
+++ b/pkg/graphql/resolver.go
@@ -3,12 +3,28 @@ package graphql
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/joincivil/id-hub/pkg/claims"
 	"github.com/joincivil/id-hub/pkg/did"
 )
 
 const (
 	resolverVersion = "1.0"
+)
+
+var (
+	// ErrAccessDenied is a generic error for unauthorized access
+	ErrAccessDenied = errors.New("access denied")
+
+	// ResponseOK is a generic OK response string
+	ResponseOK = "ok"
+
+	// ResponseError is a generic error response string
+	ResponseError = "error"
+
+	// ResponseNotImplemented is a generic response string for non-implemented endpoints
+	ResponseNotImplemented = "not implemented"
 )
 
 // Resolver is the main GraphQL resolver

--- a/pkg/idhubmain/persister.go
+++ b/pkg/idhubmain/persister.go
@@ -2,13 +2,30 @@ package idhubmain
 
 import (
 	"github.com/jinzhu/gorm"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/did"
 )
 
 func initDidPersister(db *gorm.DB) did.Persister {
 	persister := did.NewPostgresPersister(db)
-	db.AutoMigrate(
-		did.PostgresDocument{},
-	)
+	db.AutoMigrate(did.PostgresDocument{})
+	return persister
+}
+
+func initNodePersister(db *gorm.DB) *claimsstore.NodePGPersister {
+	persister := claimsstore.NewNodePGPersisterWithDB(db)
+	db.AutoMigrate(claimsstore.Node{})
+	return persister
+}
+
+func initTreePersister(db *gorm.DB) *claimsstore.PGStore {
+	nodePersister := initNodePersister(db)
+	persister := claimsstore.NewPGStore(nodePersister)
+	return persister
+}
+
+func initSignedClaimPersister(db *gorm.DB) *claimsstore.SignedClaimPGPersister {
+	persister := claimsstore.NewSignedClaimPGPersister(db)
+	db.AutoMigrate(claimsstore.SignedClaimPostgres{})
 	return persister
 }

--- a/pkg/idhubmain/server.go
+++ b/pkg/idhubmain/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	log "github.com/golang/glog"
+	"github.com/joincivil/id-hub/pkg/auth"
 	"github.com/joincivil/id-hub/pkg/graphql"
 	"github.com/joincivil/id-hub/pkg/utils"
 
@@ -53,6 +54,9 @@ func RunServer() error {
 	router.Use(middleware.RealIP)
 	router.Use(middleware.Logger)
 	router.Use(middleware.Recoverer)
+
+	// Setup the ID Hub auth middleware
+	router.Use(auth.Middleware())
 
 	queryHandler := handler.GraphQL(
 		graphql.NewExecutableSchema(

--- a/pkg/idhubmain/service.go
+++ b/pkg/idhubmain/service.go
@@ -1,9 +1,17 @@
 package idhubmain
 
 import (
+	"github.com/iden3/go-iden3-core/db"
+	"github.com/joincivil/id-hub/pkg/claims"
+	"github.com/joincivil/id-hub/pkg/claimsstore"
 	"github.com/joincivil/id-hub/pkg/did"
 )
 
 func initDidService(persister did.Persister) *did.Service {
 	return did.NewService(persister)
+}
+
+func initClaimsService(treeStore db.Storage, signedClaimStore *claimsstore.SignedClaimPGPersister,
+	didService *did.Service) (*claims.Service, error) {
+	return claims.NewService(treeStore, signedClaimStore, didService)
 }

--- a/pkg/utils/numbers.go
+++ b/pkg/utils/numbers.go
@@ -1,0 +1,15 @@
+package utils
+
+// IntOrEmptyInt returns an empty int if a int pointer is nil.
+// Otherwise returns the int value of the pointer.
+func IntOrEmptyInt(s *int) int {
+	if s != nil {
+		return *s
+	}
+	return 0
+}
+
+// IntToPtr is a convenience func that converts a int to it's pointer
+func IntToPtr(s int) *int {
+	return &s
+}

--- a/pkg/utils/numbers_test.go
+++ b/pkg/utils/numbers_test.go
@@ -1,0 +1,37 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/joincivil/id-hub/pkg/utils"
+)
+
+func TestIntOrEmptyInt(t *testing.T) {
+	res := utils.IntOrEmptyInt(nil)
+	if res != 0 {
+		t.Errorf("Should have returned an empty int")
+	}
+
+	testInt := 100
+	res = utils.IntOrEmptyInt(&testInt)
+	if res == 0 {
+		t.Errorf("Should not have returned an empty int")
+	}
+	if res != testInt {
+		t.Errorf("Should have returned the test string")
+	}
+
+	testInt = 0
+	res = utils.IntOrEmptyInt(&testInt)
+	if res != 0 {
+		t.Errorf("Should have returned an empty int")
+	}
+}
+
+func TestIntToPtr(t *testing.T) {
+	testInt := 100
+	strPtr := utils.IntToPtr(testInt)
+	if *strPtr != testInt {
+		t.Errorf("Should have returned the test int")
+	}
+}


### PR DESCRIPTION
* Adds support for getting / saving claims via GraphQL.
* Starts up claims service on server startup.
* Adds context checks for authentication on saving DIDs and claims.
* Adds a "test" to store a test DID and create new trees for testing via GraphQL.