### PR TITLE
Setup New Merkle Trees for DIDs

### DIFF
--- a/pkg/claims/creds_test.go
+++ b/pkg/claims/creds_test.go
@@ -10,6 +10,7 @@ package claims_test
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -136,7 +137,7 @@ func TestCredentialsAndGqlClaimSave(t *testing.T) {
 	t.Logf("saved did document")
 
 	// New claims tree for the DID
-	err = claimService.CreateTreeForDID(&didDoc.ID, &pubKey)
+	err = claimService.CreateTreeForDID(&didDoc.ID, []*ecdsa.PublicKey{&pubKey})
 	if err != nil {
 		t.Fatalf("problem creating did tree: %v", err)
 	}

--- a/pkg/claims/service.go
+++ b/pkg/claims/service.go
@@ -92,7 +92,7 @@ func (s *Service) CreateTreeForDID(userDid *didlib.DID, signPks []*ecdsa.PublicK
 	// Claim all the valid public keys that could be used to sign
 	var claimKey *icore.ClaimAuthorizeKSignSecp256k1
 	var pkhex string
-	var add bool
+	var addRoot bool
 	for _, k := range signPks {
 		// Check to ensure the key claim isn't already in tree
 		if isrv.CheckKSignInIddb(didMt, k) {
@@ -106,10 +106,10 @@ func (s *Service) CreateTreeForDID(userDid *didlib.DID, signPks []*ecdsa.PublicK
 		if err != nil {
 			return errors.Wrap(err, "unable to add signing key claim")
 		}
-		add = true
+		addRoot = true
 	}
 
-	if add {
+	if addRoot {
 		return s.addNewRootClaim(didMt, userDid)
 	}
 

--- a/pkg/claims/service_test.go
+++ b/pkg/claims/service_test.go
@@ -97,6 +97,8 @@ func TestCreateTreeForDID(t *testing.T) {
 	if err != nil {
 		t.Errorf("error parsing did: %v", err)
 	}
+
+	// Create the tree
 	secKey, err := crypto.HexToECDSA("79156abe7fe2fd433dc9df969286b96666489bac508612d0e16593e944c4f69f")
 	if err != nil {
 		t.Errorf("error making ecdsa: %v", err)
@@ -119,6 +121,45 @@ func TestCreateTreeForDID(t *testing.T) {
 	}
 	if len(rootClaims) != 1 {
 		t.Errorf("there should be one claim in the root tree")
+	}
+
+	// Try to put the same key in, should fail
+	err = claimService.CreateTreeForDID(userDID, []*ecdsa.PublicKey{pubKey})
+	if err != nil {
+		t.Errorf("should not have gotten err for adding an existing key")
+	}
+	didClaims, err = claimService.GetMerkleTreeClaimsForDid(userDID)
+	if err != nil {
+		t.Errorf("error getting claims for user: %v", err)
+	}
+	if len(didClaims) != 1 {
+		t.Errorf("there should be one claim in the users tree")
+	}
+
+	// Add another key to the tree, make sure using the same tree
+	secKey2, err := crypto.HexToECDSA("5dff9479ddd0b9f2213d415b5810fd7e9950ce1312a3c62fa42c6894560197a7")
+	if err != nil {
+		t.Errorf("error making ecdsa: %v", err)
+	}
+	pubKey2 := secKey2.Public().(*ecdsa.PublicKey)
+	err = claimService.CreateTreeForDID(userDID, []*ecdsa.PublicKey{pubKey2})
+	if err != nil {
+		t.Errorf("error creating tree for did: %v", err)
+	}
+	didClaims, err = claimService.GetMerkleTreeClaimsForDid(userDID)
+	if err != nil {
+		t.Errorf("error getting claims for user: %v", err)
+	}
+	if len(didClaims) != 2 {
+		t.Errorf("there should be two claims in the users tree")
+	}
+	// Should see the total claims for all dids
+	rootClaims, err = claimService.GetRootMerkleTreeClaims()
+	if err != nil {
+		t.Errorf("error getting root claims: %v", err)
+	}
+	if len(rootClaims) != 2 {
+		t.Errorf("there should be two claims in the root tree")
 	}
 }
 

--- a/pkg/did/helpers.go
+++ b/pkg/did/helpers.go
@@ -1,6 +1,7 @@
 package did
 
 import (
+	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -279,4 +280,23 @@ func ServiceInSlice(srv DocService, srvs []DocService) bool {
 		}
 	}
 	return false
+}
+
+// DocPublicKeyToEcdsaKeys converts a slice of DocPublicKey to slice of
+// corresponding ecdsa.PublicKey
+func DocPublicKeyToEcdsaKeys(pks []DocPublicKey) []*ecdsa.PublicKey {
+	var ecpub *ecdsa.PublicKey
+	var err error
+
+	ecdsaPks := make([]*ecdsa.PublicKey, 0, len(pks))
+
+	for _, pk := range pks {
+		ecpub, err = pk.AsEcdsaPubKey()
+		if err != nil {
+			continue
+		}
+		ecdsaPks = append(ecdsaPks, ecpub)
+	}
+
+	return ecdsaPks
 }

--- a/pkg/did/model_test.go
+++ b/pkg/did/model_test.go
@@ -428,3 +428,52 @@ func TestGetPublicKeyFromFragment(t *testing.T) {
 		t.Errorf("couldnt find the public key: %v", err)
 	}
 }
+
+func TestPublicKeyAsEcdsa(t *testing.T) {
+	d, _ := didlib.Parse("did:example:123456789abcdefghi")
+
+	pk := &did.DocPublicKey{
+		ID:              d,
+		Type:            linkeddata.SuiteTypeSecp256k1Verification,
+		Controller:      d,
+		EthereumAddress: utils.StrToPtr("0x5E4A048a9B8F5256a0D485e86E31e2c3F86523FB"),
+	}
+
+	key, err := pk.AsEcdsaPubKey()
+	if err == nil {
+		t.Error("should have return error for invalid ecdsa key")
+	}
+	if key != nil {
+		t.Errorf("should have returned nil key for invalid ecdsa key")
+	}
+
+	pk = &did.DocPublicKey{
+		ID:              d,
+		Type:            linkeddata.SuiteTypeEd25519Verification,
+		Controller:      d,
+		EthereumAddress: utils.StrToPtr("0x5E4A048a9B8F5256a0D485e86E31e2c3F86523FB"),
+	}
+
+	key, err = pk.AsEcdsaPubKey()
+	if err == nil {
+		t.Error("should have return error for invalid ecdsa key")
+	}
+	if key != nil {
+		t.Errorf("should have returned nil key for invalid ecdsa key")
+	}
+
+	pk = &did.DocPublicKey{
+		ID:           d,
+		Type:         linkeddata.SuiteTypeSecp256k1Verification,
+		Controller:   d,
+		PublicKeyHex: utils.StrToPtr("04debef3fcbef3f5659f9169bad80044b287139a401b5da2979e50b032560ed33927eab43338e9991f31185b3152735e98e0471b76f18897d764b4e4f8a7e8f61b"),
+	}
+
+	key, err = pk.AsEcdsaPubKey()
+	if err != nil {
+		t.Error("should not have error for invalid ecdsa key")
+	}
+	if key == nil {
+		t.Errorf("should have not returned nil key for invalid ecdsa key")
+	}
+}

--- a/pkg/graphql/claim_resolver.go
+++ b/pkg/graphql/claim_resolver.go
@@ -78,7 +78,7 @@ func (r *mutationResolver) ClaimSave(ctx context.Context, in *ClaimSaveRequestIn
 		return nil, errors.Wrap(err, "error parsing issuer did")
 	}
 
-	err = r.ClaimService.CreateTreeForDIDIfNotExists(issuerDID)
+	err = r.ClaimService.CreateTreeForDID(issuerDID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create tree for did if not exists")
 	}

--- a/pkg/graphql/claim_resolver.go
+++ b/pkg/graphql/claim_resolver.go
@@ -73,6 +73,16 @@ func (r *mutationResolver) ClaimSave(ctx context.Context, in *ClaimSaveRequestIn
 		return nil, ErrAccessDenied
 	}
 
+	issuerDID, err := didlib.Parse(cc.Issuer)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing issuer did")
+	}
+
+	err = r.ClaimService.CreateTreeForDIDIfNotExists(issuerDID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create tree for did if not exists")
+	}
+
 	err = r.ClaimService.ClaimContent(cc)
 	if err != nil {
 		return nil, errors.Wrap(err, "error calling claimcontent")

--- a/pkg/graphql/did_resolver.go
+++ b/pkg/graphql/did_resolver.go
@@ -111,6 +111,7 @@ func (r *mutationResolver) DidSave(ctx context.Context, in *DidSaveRequestInput)
 		return nil, errors.Wrap(err, "unable to parse the incoming did")
 	}
 
+	// Adds any keys that don't exist into the claims tree (or creates the tree)
 	err = r.ClaimService.CreateTreeForDID(inDid, did.DocPublicKeyToEcdsaKeys(doc.PublicKeys))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to add keys or create tree for did")

--- a/pkg/graphql/did_resolver.go
+++ b/pkg/graphql/did_resolver.go
@@ -112,7 +112,7 @@ func (r *mutationResolver) DidSave(ctx context.Context, in *DidSaveRequestInput)
 	}
 
 	// Adds any keys that don't exist into the claims tree (or creates the tree)
-	err = r.ClaimService.CreateTreeForDID(inDid, did.DocPublicKeyToEcdsaKeys(doc.PublicKeys))
+	err = r.ClaimService.CreateTreeForDIDWithPks(inDid, did.DocPublicKeyToEcdsaKeys(doc.PublicKeys))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to add keys or create tree for did")
 	}

--- a/pkg/graphql/did_resolver.go
+++ b/pkg/graphql/did_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	log "github.com/golang/glog"
+	didlib "github.com/ockam-network/did"
 
 	"github.com/pkg/errors"
 
@@ -103,6 +104,16 @@ func (r *mutationResolver) DidSave(ctx context.Context, in *DidSaveRequestInput)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create or update doc")
+	}
+
+	inDid, err := didlib.Parse(*in.Did)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse the incoming did")
+	}
+
+	err = r.ClaimService.CreateTreeForDID(inDid, did.DocPublicKeyToEcdsaKeys(doc.PublicKeys))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to add keys or create tree for did")
 	}
 
 	return &DidSaveResponse{Doc: doc}, nil


### PR DESCRIPTION
* Sets up new merkle trees for DIDs.
* Adds new key signing claims to the existing and new trees.
* Allows adding multiple key signing claims to trees.
* Adds check for existing tree for a DID.

This tries to create a new tree on did save and checks tree existence on claim save.  Let know if this is a sound strategy and if this code make sense at all.  Seems like we could get rid of the tree existence check and just re-use `CreateNewTreeForDID` in all places.

cc/ @walfly 