### PR TITLE
Add Coveralls Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ defaults: &defaults
 jobs:
   build:
     <<: *defaults
-    # working_directory: /go/src/github.com/joincivil/id-hub
     working_directory: ~/repos/id-hub
     environment:
     steps:
@@ -64,10 +63,10 @@ jobs:
             - go.sum
             - scripts
             - .golangci.yml
+            - .git
 
   lint:
     <<: *defaults
-    # working_directory: /go/src/github.com/joincivil/id-hub
     working_directory: ~/repos/id-hub
     environment:
     steps:
@@ -89,7 +88,6 @@ jobs:
 
   test:
     <<: *defaults
-    # working_directory: /go/src/github.com/joincivil/id-hub
     working_directory: ~/repos/id-hub
     environment:
     steps:
@@ -104,16 +102,36 @@ jobs:
             DB_URL: "postgres://root@localhost:5432/circle_test?sslmode=disable"
             DB_MIGRATIONS: ~/repos/id-hub/migrations
           command: |
-            make test
+            make test-integration
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - coverage.txt
+
+  coveralls:
+    <<: *defaults
+    working_directory: ~/repos/id-hub
+    environment:
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Setting up tools
+          command: |
+            make install-gobin
+            make install-goveralls
+      - run:
+          name: Push coverage data to Coveralls
+          command: |
+            make to-coveralls
 
   setup-gcp:
     docker:
       - image: civilmedia/gcloud-node:latest
-    # working_directory: /go/src/github.com/joincivil/id-hub
     working_directory: ~/repos/id-hub
     steps:
       - run:
@@ -138,7 +156,6 @@ jobs:
   push-container:
     docker:
       - image: civilmedia/gcloud-node:latest
-    # working_directory: /go/src/github.com/joincivil/id-hub
     working_directory: ~/repos/id-hub
     steps:
       - attach_workspace:
@@ -161,6 +178,7 @@ jobs:
             gcloud config list
             echo "pushing $GOOGLE_PROJECT_ID"
             docker push gcr.io/$GOOGLE_PROJECT_ID/$CIRCLE_PROJECT_REPONAME
+
   deploy-staging:
     docker:
       - image: civilmedia/gcloud-node:latest
@@ -172,6 +190,7 @@ jobs:
           name: Update Kubernetes Deployment on STAGING
           command: |
             kubectl set image deployment/$CIRCLE_PROJECT_REPONAME $CIRCLE_PROJECT_REPONAME=gcr.io/$GOOGLE_PROJECT_ID/$CIRCLE_PROJECT_REPONAME:master-$CIRCLE_SHA1 --namespace staging
+
   deploy-production:
     docker:
       - image: civilmedia/gcloud-node:latest
@@ -196,6 +215,15 @@ workflows:
       - lint:
           requires:
             - build
+      - coveralls:
+          requires:
+            - build
+            - test
+          filters:
+            branches:
+              only:
+                - png/coveralls-support
+                - master
       - setup-gcp:
           context: gcp-common
           requires:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CircleCI](https://img.shields.io/circleci/project/github/joincivil/id-hub.svg)](https://circleci.com/gh/joincivil/id-hub/tree/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/joincivil/id-hub)](https://goreportcard.com/report/github.com/joincivil/id-hub)
-
+[![Coverage Status](https://coveralls.io/repos/github/joincivil/id-hub/badge.svg)](https://coveralls.io/github/joincivil/id-hub)
 
 ## Contributing
 

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sendgrid/rest v2.4.1+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
 github.com/sendgrid/sendgrid-go v0.0.0-20180905233524-8cb43f4ca4f5/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=


### PR DESCRIPTION
To allow us to easily see test coverage since it is free for open-source projects.

We don't have a lot of coverage for the GQL resolvers, so that's why our current percentage is pretty low, but our critical modules have decent coverage right now.