### PR TITLE
Fix for PGStore Test

### DIFF
--- a/pkg/auth/signature.go
+++ b/pkg/auth/signature.go
@@ -177,7 +177,6 @@ func SignEcdsaRequestMessage(privKey *ecdsa.PrivateKey, did string, reqTs int) (
 // with no 0x prefix.
 func SignMessage(privKey *ecdsa.PrivateKey, message []byte) (string, error) {
 	hash := crypto.Keccak256(message)
-	fmt.Printf("hash = %v\n", hex.EncodeToString(hash))
 	signature, err := crypto.Sign(hash, privKey)
 	if err != nil {
 		return "", err

--- a/pkg/claimsstore/nodepersister.go
+++ b/pkg/claimsstore/nodepersister.go
@@ -107,7 +107,7 @@ func (c *NodePGPersister) Get(key []byte) (*Node, error) {
 
 // Batch updates many nodes at once from the cached kv values
 // used to update all the middle nodes when a leaf is added or changed
-func (c *NodePGPersister) Batch(cache kvMap, prefix []byte) error {
+func (c *NodePGPersister) Batch(cache *kvMap, prefix []byte) error {
 	tx := c.DB.Begin()
 
 	defer func() {
@@ -116,7 +116,9 @@ func (c *NodePGPersister) Batch(cache kvMap, prefix []byte) error {
 		}
 	}()
 	var node Node
-	for _, v := range cache {
+	var v db.KV
+	for _, key := range cache.order {
+		v = cache.kv[key]
 		node = Node{}
 		if err := tx.FirstOrCreate(&node, Node{NodeKey: hex.EncodeToString(v.K)}).Error; err != nil {
 			tx.Rollback()

--- a/pkg/claimsstore/pgstore.go
+++ b/pkg/claimsstore/pgstore.go
@@ -20,7 +20,8 @@ func NewPGStore(nodePersister *NodePGPersister) *PGStore {
 
 // NewTx creates a new transaction
 func (s *PGStore) NewTx() (db.Tx, error) {
-	return &PGTX{s, make(kvMap)}, nil
+	kv := newKvMap()
+	return &PGTX{s, kv}, nil
 }
 
 // WithPrefix returns a new instance of the pgstore using the passed in prefix


### PR DESCRIPTION
Maps do not retain order, so this resulted in intermittent situations where the values returned from the store were not in an expected order. Query by timestamp didn't work since all the items were stored at the same timestamp.

The fix here is to alter `kvMap` and add an ordered slice of keys alongside the map to retain order. When the `Batch` method runs, the code will persist according to the order of keys in the ordered slice.