### PR TITLE
Use `MethodIDOnly` DID for Persister Queries

### DIFF
--- a/pkg/did/inmemorypersister.go
+++ b/pkg/did/inmemorypersister.go
@@ -15,7 +15,8 @@ func (p *InMemoryPersister) GetDocument(d *didlib.DID) (*Document, error) {
 	if p.store == nil {
 		p.store = map[string]*Document{}
 	}
-	doc, ok := p.store[d.String()]
+	theDID := MethodIDOnly(d)
+	doc, ok := p.store[theDID]
 	if !ok {
 		return nil, nil
 	}
@@ -27,6 +28,7 @@ func (p *InMemoryPersister) SaveDocument(doc *Document) error {
 	if p.store == nil {
 		p.store = map[string]*Document{}
 	}
-	p.store[doc.ID.String()] = doc
+	theDID := MethodIDOnly(&doc.ID)
+	p.store[theDID] = doc
 	return nil
 }

--- a/pkg/did/postgrespersister.go
+++ b/pkg/did/postgrespersister.go
@@ -27,7 +27,7 @@ func (p *PostgresPersister) GetDocument(d *didlib.DID) (*Document, error) {
 		return nil, errors.New("nil did for get document")
 	}
 
-	theDID := d.String()
+	theDID := MethodIDOnly(d)
 
 	doc := &PostgresDocument{}
 	err := p.db.Where(&PostgresDocument{DID: theDID}).First(doc).Error
@@ -50,7 +50,7 @@ func (p *PostgresPersister) SaveDocument(doc *Document) error {
 	}
 
 	updated := &PostgresDocument{}
-	err = p.db.Where(&PostgresDocument{DID: doc.ID.String()}).
+	err = p.db.Where(&PostgresDocument{DID: MethodIDOnly(&doc.ID)}).
 		Assign(&PostgresDocument{Document: dbdoc.Document}).
 		FirstOrCreate(updated).Error
 	if err != nil {


### PR DESCRIPTION
It was looking for the entire did, including fragments and paths, when we just store by DID with no method/id in the DB.