### PR TITLE
Log GQL Original and Cause Errors

### DIFF
--- a/pkg/idhubmain/server.go
+++ b/pkg/idhubmain/server.go
@@ -83,14 +83,14 @@ func RunServer() error {
 		handler.ErrorPresenter(
 			func(ctx context.Context, e error) *gqlerror.Error {
 				err := errors.Cause(e)
-				log.Errorf("gql error: %+v", err)
+				log.Errorf("gql error: err: %+v, cause: %+v", e, err)
 				return gqlgen.DefaultErrorPresenter(ctx, err)
 			},
 		),
 		handler.RecoverFunc(func(ctx context.Context, err interface{}) error {
 			switch val := err.(type) {
 			case error:
-				log.Errorf("gql panic error: %+v", errors.Cause(val))
+				log.Errorf("gql panic error: err: %+v, cause: %+v", val, errors.Cause(val))
 			}
 			return fmt.Errorf("Internal server error: %v", err)
 		}),


### PR DESCRIPTION
The wrapping messages are being stripped so hard to trace the errors. Now logging both the raw error as-is and the cause.