### PR TITLE
Allow Run w/o Root Commits Address

### DIFF
--- a/pkg/claims/service.go
+++ b/pkg/claims/service.go
@@ -149,6 +149,10 @@ func (s *Service) makeContentClaimFromCred(claim claimtypes.Credential,
 
 // GenerateProof returns a proof that the content credential is in the tree and on the blockchain
 func (s *Service) GenerateProof(claim claimtypes.Credential, claimer *didlib.DID) (*MTProof, error) {
+	if s.rootService == nil {
+		return nil, errors.New("Unable to generate proof, no root service initialized")
+	}
+
 	lastRootCommit, err := s.rootService.GetLatest()
 	if err != nil {
 		return nil, errors.Wrap(err, "GenerateProof.rootService.GetLatest")

--- a/pkg/idhubmain/service.go
+++ b/pkg/idhubmain/service.go
@@ -2,6 +2,7 @@ package idhubmain
 
 import (
 	"github.com/ethereum/go-ethereum"
+	log "github.com/golang/glog"
 	"github.com/iden3/go-iden3-core/db"
 	"github.com/joincivil/go-common/pkg/eth"
 	"github.com/joincivil/go-common/pkg/lock"
@@ -22,7 +23,16 @@ func initClaimsService(treeStore *claimsstore.PGStore, signedClaimStore *claimss
 
 func initRootService(config *utils.IDHubConfig, ethHelper *eth.Helper,
 	treeStore db.Storage, persister *claimsstore.RootCommitsPGPersister) (*claims.RootService, error) {
-	rootCommitter, err := claims.NewRootCommitter(ethHelper, ethHelper.Blockchain.(ethereum.TransactionReader), config.RootCommitsAddress)
+	if config.RootCommitsAddress == "" {
+		log.Errorf("No root commits address set, disabling root commits access")
+		return nil, nil
+	}
+
+	rootCommitter, err := claims.NewRootCommitter(
+		ethHelper,
+		ethHelper.Blockchain.(ethereum.TransactionReader),
+		config.RootCommitsAddress,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Allows us to start up the server without the root commits address being available.  This will allow us to start capturing the claims before the root commits contract is up and available.  Since there is no contract available, the proofs generation is disabled if no root contract is specified.

This will help get this up on production to store claims while we figure out the deployment of the smart contract.